### PR TITLE
elasticsearch 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Initial release, forked from [sat-api](https://github.com/sat-utils/sat-api/tree
 
 Compliant with STAC 0.9.0
 
-[Unreleased]: https://github.com/stac-utils/stac-api/compare/master...develop
+[Unreleased]: https://github.com/stac-utils/stac-api/compare/0.2.1...main
 [0.2.1]: https://github.com/stac-utils/stac-api/compare/0.1.0...0.2.1
 [0.2.0]: https://github.com/stac-utils/stac-api/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/stac-utils/stac-api/tree/0.1.0

--- a/fixtures/collections.js
+++ b/fixtures/collections.js
@@ -2,27 +2,13 @@ const common = require('./common.js')
 
 module.exports = () => ({
   mappings: {
-    doc: {
-      dynamic_templates: common.dynamic_templates,
-      properties: {
-        extent: {
-          type: 'object',
-          properties: {
-            spatial: { 
-              type: 'object',
-              properties: {
-                bbox: { type: 'long' }
-              }
-            },
-            temporal: {
-              type: 'object',
-              properties: {
-                interval: { type: 'date' }
-              }
-            }
-          }
-        }
-      }
+    dynamic_templates: common.dynamic_templates,
+    properties: {
+      "extent.spatial.bbox": { type: "long" },
+      "extent.temporal.interval": { type: "date" },
+      "providers": { type: "object", enabled: false },
+      "links": { type: "object", enabled: false },
+      "item_assets": { type: "object", enabled: false },
     }
   }
 })

--- a/fixtures/items.js
+++ b/fixtures/items.js
@@ -2,12 +2,12 @@ const common = require('./common.js')
 
 module.exports = () => ({
   mappings: {
-    doc: {
-      dynamic_templates: common.dynamic_templates,
-      properties: {
-        geometry: { type: 'geo_shape' },
-        properties: common.properties
-      }
+    dynamic_templates: common.dynamic_templates,
+    properties: {
+      geometry: { type: 'geo_shape' },
+      properties: common.properties,
+      assets: { type: "object", enabled: false },
+      links: { type: "object", enabled: false },
     }
   }
 })

--- a/libs/es.js
+++ b/libs/es.js
@@ -327,12 +327,12 @@ async function search(parameters, page = 1, limit = 10) {
     context: {
       page: Number(page),
       limit: Number(limit),
-      matched: esResponse.body.hits.total,
+      matched: esResponse.body.hits.total.value,
       returned: results.length
     },
     links: []
   }
-  const nextlink = (((page * limit) < esResponse.body.hits.total) ? page + 1 : null)
+  const nextlink = (((page * limit) < esResponse.body.hits.total.value) ? page + 1 : null)
   if (nextlink) {
     response.links.push({
       title: 'next',

--- a/libs/esStream.js
+++ b/libs/esStream.js
@@ -56,7 +56,7 @@ class ElasticSearchWritableStream extends _stream.Writable {
 
       await this.client.update({
         index,
-        type: 'doc',
+        type: '_doc',
         id,
         body
       })
@@ -127,7 +127,6 @@ async function stream() {
       // create ES record
       const record = {
         index,
-        type: 'doc',
         id: esDataObject.id,
         action: 'update',
         _retry_on_conflict: 3,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@acuris/aws-es-connection": "^1.1.0",
-    "@elastic/elasticsearch": "^6.8",
+    "@elastic/elasticsearch": "^7.9",
     "@mapbox/extent": "^0.4.0",
     "geojson-validation": "^0.2.1",
     "js-yaml": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "stac-server",
   "description": "A STAC API running on stac-server",
-  "version": "0.2.0",
+  "version": "0.3.0-dev",
   "repository": "https://github.com/stac-utils/stac-server",
   "author": "Alireza Jazayeri, Matthew Hanson <matt.a.hanson@gmail.com>, Sean Harkins",
   "license": "MIT",

--- a/serverless.yml
+++ b/serverless.yml
@@ -128,7 +128,7 @@ resources:
           InstanceCount: 3
           DedicatedMasterEnabled: false
           ZoneAwarenessEnabled: false
-        ElasticsearchVersion: 6.8
+        ElasticsearchVersion: 7.9
   Outputs:
     ESEndpoint:
       Value:

--- a/serverless.yml
+++ b/serverless.yml
@@ -52,7 +52,7 @@ functions:
     description: stac-server Ingest Lambda
     handler: index.handler
     memorySize: 512
-    timeout: 15
+    timeout: 30
     package:
       artifact: lambdas/ingest/dist/ingest.zip
     events:


### PR DESCRIPTION
Update from elasticsearch 6.8 to 7.9, resolves #65 

Also updated mappings to exclude objects like `links` and `assets`, since they are not searchable anyway through the API. Resolves #69 and #68