### PR TITLE
Set default instance type to t3.small and enforce HTTPS

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -124,11 +124,13 @@ resources:
           VolumeType: gp2
           VolumeSize: 35
         ElasticsearchClusterConfig:
-          InstanceType: t2.small.elasticsearch
+          InstanceType: t3.small.elasticsearch
           InstanceCount: 3
           DedicatedMasterEnabled: false
           ZoneAwarenessEnabled: false
         ElasticsearchVersion: 7.9
+        DomainEndpointOptions:
+          EnforceHTTPS: true
   Outputs:
     ESEndpoint:
       Value:


### PR DESCRIPTION
t3.small is cheaper than t2.small (and newer generation hardware). In addition it allows setting security configuration if desired, such as `NodeToNodeEncryptionOptions` and `EncryptionAtRestOptions`. This PR also contains a config change to force HTTPS, which is desired in all cases