### PR TITLE
SQS Timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following APIs are deployed instances of stac-server:
 
 | Name     | Version   | Description |
 | -------- | ----      | ----        |
-| [Earth Search](https://earth-search-v0.aws.element84.com/) | 0.9.0 | Catalog of some AWS Public Datasets |
+| [Earth Search](https://earth-search.aws.element84.com/v0/) | 1.0.0-beta.2 | Catalog of some AWS Public Datasets |
 
 
 ## Usage

--- a/lambdas/api/index.js
+++ b/lambdas/api/index.js
@@ -4,7 +4,7 @@ const httpMethods = require('../../utils/http-methods')
 
 
 function determineEndpoint(event) {
-  let endpoint = process.env.STAC_ROOT_URL
+  let endpoint = process.env.STAC_API_URL
   if (typeof endpoint === 'undefined') {
     if ('X-Forwarded-Host' in event.headers) {
       endpoint = `${event.headers['X-Forwarded-Proto']}://${event.headers['X-Forwarded-Host']}`

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,8 +40,8 @@ functions:
     package:
       artifact: lambdas/api/dist/api.zip
     events:
-      - http: 
-          method: ANY 
+      - http:
+          method: ANY
           path: "/"
           cors: true
       - http:
@@ -86,7 +86,7 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         DelaySeconds: 1
-        VisibilityTimeout: 25
+        VisibilityTimeout: 45
         ReceiveMessageWaitTimeSeconds: 5
         QueueName: ${self:service}-${self:provider.stage}-queue
         RedrivePolicy:


### PR DESCRIPTION
Hi All! 

**Thanks for doing what you do for the greater geospatial community! This has been a wonderfully helpful project and I cannot thank you enough for keeping it open source.** 

I split these into 3 commits so they're easier to review:
1. Upping the SQS `VisibilityTimeout` to above the lambda one cleared a Serverless deployment issue
2. `STAC_API_URL` wasn't called anywhere and `STAC_ROOT_URL` wasn't populating, so I swapped `STAC_API_URL` into the API Lambda (not sure if I was right here or not)
3. Added your correct endpoint to your README.md

Thanks again! 🍻