### PR TITLE
Only JSON.stringify Object, not string

### DIFF
--- a/libs/api.js
+++ b/libs/api.js
@@ -302,7 +302,11 @@ const buildPageLinks = function (meta, parameters, endpoint, httpMethod) {
       (p) => {
         //TODO: how did this work without JSON.stringify?
         // const query = encodeURIComponent(dict[p])
-        const query = encodeURIComponent(JSON.stringify(dict[p]))
+        let value = dict[p]
+        if (typeof value === 'object' && value !== null) {
+          value = JSON.stringify(value)
+        }
+        const query = encodeURIComponent(value)
         if (p === 'collections') {
           return `${encodeURIComponent(p)}[]=${query}`
         } else {

--- a/tests/integration/test_api.js
+++ b/tests/integration/test_api.js
@@ -14,8 +14,7 @@ const endpoint = 'endpoint'
 test('collections', async (t) => {
   const response = await API('/collections', {}, backend, endpoint)
   t.is(response.collections.length, 2)
-  // the 'meta' field is not STAC API mandate, but is a nicety
-  t.is(response.meta.returned, 2)
+  t.is(response.context.returned, 2)
 })
 
 test('collections/{collectionId}', async (t) => {
@@ -401,4 +400,20 @@ test('search preserve geometry in page GET links', async (t) => {
   }, backend, endpoint)
 
   t.is(response.features.length, 1)
+
+  const datetime = '2015-02-19/2015-02-20'
+  response = await API('/search', {
+    intersects: intersectsGeometry,
+    datetime: datetime,
+    limit: 1
+  }, backend, endpoint)
+  t.is(response.features.length, 1)
+
+  const next = response.links[0].href
+  const params = {}
+  next.split('?', 2)[1].split('&').forEach((pair) => {
+    const [key, val] = pair.split('=', 2)
+    params[key] = decodeURIComponent(val)
+  })
+  t.is(params.datetime, datetime)
 })


### PR DESCRIPTION
The issue was that I was converting a string to a JSON string which adds extra quotes.

I added integration test for this fix to make sure this is not broken again. Will further extend tests to check that other parameters are not malformed in next link.