### PR TITLE
removed Root API Version from root STAC catalog

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -10,7 +10,6 @@ provider:
     STAC_TITLE: "STAC API"
     STAC_DESCRIPTION: "A STAC API using stac-server"
     STAC_VERSION: 1.0.0
-    STAC_API_VERSION: 1.0.0-beta.1
     LOG_LEVEL: DEBUG
     ES_BATCH_SIZE: 500
     STAC_DOCS_URL: https://stac-utils.github.io/stac-server/


### PR DESCRIPTION
I removed the "STAC_API_VERSION' key from the serverless.yml file so that it does not appear in the STAC Root Catalog.