### PR TITLE
Fix bug where all ES connections in pool were dead

### DIFF
--- a/libs/esStream.js
+++ b/libs/esStream.js
@@ -13,10 +13,6 @@ class ElasticSearchWritableStream extends _stream.Writable {
     this.client = this.config.client
   }
 
-  _destroy() {
-    return this.client.close()
-  }
-
   // Allows the flexibility to batch write to multiple indexes.
   transformRecords(chunks) {
     const operations = chunks.reduce((bulkOperations, chunk) => {


### PR DESCRIPTION
Closes #152

The issue was that the `ElasticSearchWritableStream` was closing its client when it was destroyed, which ended up closing the clients that other operations were trying to use.