### PR TITLE
Return empty results when searching for a nonexistent collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Open-ended datetime intervals using either empty string or '..' now work
 - Correct content types are now returned
+- Searching for a nonexistent collection returns empty results
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "js-yaml": "^3.13.1",
         "memorystream": "^0.3.1",
         "morgan": "^1.10.0",
+        "p-filter": "^2.0.0",
         "pump": "^3.0.0",
         "serverless-http": "^2.7.0",
         "through2": "^3.0.1"
@@ -10880,6 +10881,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-filter/node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/p-finally": {
@@ -26511,6 +26531,21 @@
       "dev": true,
       "requires": {
         "p-timeout": "^3.1.0"
+      }
+    },
+    "p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "requires": {
+        "p-map": "^2.0.0"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+        }
       }
     },
     "p-finally": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "js-yaml": "^3.13.1",
     "memorystream": "^0.3.1",
     "morgan": "^1.10.0",
+    "p-filter": "^2.0.0",
     "pump": "^3.0.0",
     "serverless-http": "^2.7.0",
     "through2": "^3.0.1"

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,6 +1,7 @@
 const gjv = require('geojson-validation')
 const extent = require('@mapbox/extent')
-const { isIndexNotFoundError } = require('./es')
+const pFilter = require('p-filter')
+const { isIndexNotFoundError, indexExists } = require('./es')
 const logger = console
 
 // max number of collections to retrieve
@@ -378,6 +379,10 @@ const searchItems = async function (collectionId, queryParameters, backend, endp
   const ids = extractIds(queryParameters)
   const collections = extractCollectionIds(queryParameters)
 
+  const collectionsThatExist = Array.isArray(collections)
+    ? await pFilter(collections, indexExists)
+    : undefined
+
   const parameters = {
     datetime,
     intersects,
@@ -385,7 +390,7 @@ const searchItems = async function (collectionId, queryParameters, backend, endp
     sortby,
     fields,
     ids,
-    collections
+    collections: collectionsThatExist
   }
 
   // Keep only existing parameters

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,6 @@
 const gjv = require('geojson-validation')
 const extent = require('@mapbox/extent')
+const { isIndexNotFoundError } = require('./es')
 const logger = console
 
 // max number of collections to retrieve
@@ -401,7 +402,26 @@ const searchItems = async function (collectionId, queryParameters, backend, endp
     newEndpoint = `${endpoint}/collections/${collectionId}/items`
   }
   logger.debug(`Search parameters: ${JSON.stringify(searchParameters)}`)
-  const results = await backend.search(searchParameters, page, limit)
+
+  let results
+  try {
+    results = await backend.search(searchParameters, page, limit)
+  } catch (error) {
+    if (isIndexNotFoundError(error)) {
+      results = {
+        context: {
+          matched: 0,
+          returned: 0,
+          page,
+          limit
+        },
+        results: []
+      }
+    } else {
+      throw error
+    }
+  }
+
   const { 'results': itemsResults, 'context': itemsMeta } = results
   const pageLinks = buildPageLinks(itemsMeta, searchParameters, newEndpoint, httpMethod)
   const items = addItemLinks(itemsResults, endpoint)

--- a/src/lib/es.js
+++ b/src/lib/es.js
@@ -6,6 +6,11 @@ const logger = console //require('./logger')
 const COLLECTIONS_INDEX = process.env.COLLECTIONS_INDEX || 'collections'
 const ITEMS_INDEX = process.env.ITEMS_INDEX || 'items'
 
+const isIndexNotFoundError = (e) => (
+  e instanceof Error
+    && e.name === 'ResponseError'
+    && e.message.includes('index_not_found_exception'))
+
 /*
 This module is used for connecting to an Elasticsearch instance, writing records,
 searching records, and managing the indexes. It looks for the ES_HOST environment
@@ -354,6 +359,7 @@ async function search(parameters, page = 1, limit = 10) {
 module.exports = {
   getCollection,
   getCollections,
+  isIndexNotFoundError,
   search,
   editPartialItem,
   constructSearchParams,

--- a/src/lib/es.js
+++ b/src/lib/es.js
@@ -356,9 +356,24 @@ async function search(parameters, page = 1, limit = 10) {
   return response
 }
 
+/**
+ * Test if an ES index exists
+ *
+ * @param {string} index
+ * @returns {Promise<boolean>}
+ */
+const indexExists = async (index) => {
+  const client = await esClient.client()
+
+  const result = await client.indices.exists({ index })
+
+  return result.body
+}
+
 module.exports = {
   getCollection,
   getCollections,
+  indexExists,
   isIndexNotFoundError,
   search,
   editPartialItem,

--- a/tests/system/test-api.js
+++ b/tests/system/test-api.js
@@ -190,7 +190,20 @@ test('/', async (t) => {
 })
 
 test('GET /search returns an empty list of results for a collection that does not exist', async (t) => {
-  const response = await apiClient.get('search', {
+  const collectionId = randomId('collection')
+  const searchParams = new URLSearchParams({ collections: [collectionId] })
+
+  const response = await apiClient.get('search', { searchParams })
+
+  t.true(Array.isArray(response.features))
+  t.is(response.features.length, 0)
+})
+
+test('POST /search returns an empty list of results for a collection that does not exist', async (t) => {
+  const response = await apiClient.post('search', {
+    json: {
+      collections: [randomId('collection')]
+    },
     searchParams: {
       collections: randomId('collection')
     }
@@ -200,10 +213,13 @@ test('GET /search returns an empty list of results for a collection that does no
   t.is(response.features.length, 0)
 })
 
-test('POST /search returns an empty list of results for a collection that does not exist', async (t) => {
+test("POST /search returns results when one collection exists and another doesn't", async (t) => {
   const response = await apiClient.post('search', {
     json: {
-      collections: randomId('collection')
+      collections: [
+        'collection2',
+        randomId('collection')
+      ]
     },
     searchParams: {
       collections: randomId('collection')
@@ -211,7 +227,7 @@ test('POST /search returns an empty list of results for a collection that does n
   })
 
   t.true(Array.isArray(response.features))
-  t.is(response.features.length, 0)
+  t.true(response.features.length > 0)
 })
 
 test.skip('/search bbox', async (t) => {

--- a/tests/system/test-api.js
+++ b/tests/system/test-api.js
@@ -3,6 +3,7 @@ const { apiClient } = require('../helpers/api-client')
 const intersectsGeometry = require('../fixtures/stac/intersectsGeometry.json')
 const noIntersectsGeometry = require('../fixtures/stac/noIntersectsGeometry.json')
 const { refreshIndices } = require('../helpers/es')
+const { randomId } = require('../helpers/utils')
 
 test('/collections', async (t) => {
   await refreshIndices()
@@ -160,6 +161,31 @@ test('/collections/{collectionId}/items with gt lt query', async (t) => {
 test('/', async (t) => {
   const response = await apiClient.get('')
   t.is(response.links.length, 8)
+})
+
+test('GET /search returns an empty list of results for a collection that does not exist', async (t) => {
+  const response = await apiClient.get('search', {
+    searchParams: {
+      collections: randomId('collection')
+    }
+  })
+
+  t.true(Array.isArray(response.features))
+  t.is(response.features.length, 0)
+})
+
+test('POST /search returns an empty list of results for a collection that does not exist', async (t) => {
+  const response = await apiClient.post('search', {
+    json: {
+      collections: randomId('collection')
+    },
+    searchParams: {
+      collections: randomId('collection')
+    }
+  })
+
+  t.true(Array.isArray(response.features))
+  t.is(response.features.length, 0)
 })
 
 test.skip('/search bbox', async (t) => {


### PR DESCRIPTION
Closes #156

Also handles the case where a user searches for multiple collections but some of those collections don't exist. In that case, only results for the collections that exist are returned.