### PR TITLE
fix service-desc link relation type to use OpenAPI yaml media type

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -451,7 +451,7 @@ const getCatalog = async function (backend, endpoint = '') {
   let catalog = collectionsToCatalogLinks(collections, endpoint)
   catalog.links.push({
     rel: 'service-desc',
-    type: 'application/vnd.oai.openapi+json;version=3.0',
+    type: 'application/vnd.oai.openapi',
     href: `${endpoint}/api`
   })
   catalog.links.push({

--- a/tests/system/test-api-get-api.js
+++ b/tests/system/test-api-get-api.js
@@ -1,8 +1,8 @@
 const test = require('ava')
 const { apiClient } = require('../helpers/api-client')
 
-test('GET /api has a content type of "application/json', async (t) => {
+test('GET /api has a content type of application/vnd.oai.openapi', async (t) => {
   const response = await apiClient.get('api', { resolveBodyOnly: false })
 
-  t.is(response.headers['content-type'], 'application/vnd.oai.openapi')
+  t.is(response.headers['content-type'], 'application/vnd.oai.openapi; charset=utf-8')
 })

--- a/tests/system/test-api-get-api.js
+++ b/tests/system/test-api-get-api.js
@@ -4,5 +4,5 @@ const { apiClient } = require('../helpers/api-client')
 test('GET /api has a content type of "application/json', async (t) => {
   const response = await apiClient.get('api', { resolveBodyOnly: false })
 
-  t.is(response.headers['content-type'], 'application/vnd.oai.openapi; charset=utf-8')
+  t.is(response.headers['content-type'], 'application/vnd.oai.openapi')
 })

--- a/tests/unit/test-api-search.js
+++ b/tests/unit/test-api-search.js
@@ -37,7 +37,7 @@ test.skip('search /', async (t) => {
   const expectedLinks = [
     {
       rel: 'service-desc',
-      type: 'application/vnd.oai.openapi+json;version=3.0',
+      type: 'application/vnd.oai.openapi',
       href: 'endpoint/api'
     },
     {


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. advertise OpenAPI yaml media type instead of json media type, to match what the /api endpoint actually returns.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
