### PR TITLE
Move addEndpoint middleware

### DIFF
--- a/src/lambdas/api/middleware/add-endpoint.js
+++ b/src/lambdas/api/middleware/add-endpoint.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+/**
+ * @typedef {import('express').Request} Request
+ * @typedef {import('express').Response} Response
+ * @typedef {import('express').NextFunction} NextFunction
+ */
+
+/**
+ * @param {Request} req
+ * @returns {string}
+ */
+const determineEndpoint = (req) => {
+  if (process.env['STAC_API_URL']) return process.env['STAC_API_URL']
+
+  if (req.get('X-Forwarded-Host')) {
+    return `${req.get('X-Forwarded-Proto')}://${req.get('X-Forwarded-Host')}`
+  }
+
+  return req.event && req.event.requestContext && req.event.requestContext.stage
+    ? `${req.get('X-Forwarded-Proto')}://${req.get('Host')}/${req.event.requestContext.stage}`
+    : `${req.get('X-Forwarded-Proto')}://${req.get('Host')}`
+}
+
+/**
+ * @param {Request} req
+ * @param {Response} _res
+ * @param {NextFunction} next
+ * @returns {void}
+ */
+const addEndpoint = (req, _res, next) => {
+  req.endpoint = determineEndpoint(req)
+  next()
+}
+
+module.exports = {
+  addEndpoint
+}


### PR DESCRIPTION
As we add more middleware to the API, we're going to want to keep it organized.

This PR moves the `addEndpoint` middleware into its own file