### PR TITLE
Add support for X-STAC-Endpoint header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   were not advertised in the landing page conformsTo attribute or the /conformance endpoint.
 - Items larger than 256 KB can now be ingested by writing their contents to S3
 - API responses are now compressed
+- If a request includes the `X-STAC-Endpoint` header, that endpoint will be used when generating link hrefs
 
 ### Fixed
 

--- a/src/lambdas/api/middleware/add-endpoint.js
+++ b/src/lambdas/api/middleware/add-endpoint.js
@@ -11,9 +11,12 @@
  * @returns {string}
  */
 const determineEndpoint = (req) => {
+  const xStacEndpoint = req.get('X-STAC-Endpoint')
+  if (xStacEndpoint) return xStacEndpoint
+
   if (process.env['STAC_API_URL']) return process.env['STAC_API_URL']
 
-  if (req.get('X-Forwarded-Host')) {
+  if (req.get('X-Forwarded-Proto') && req.get('X-Forwarded-Host')) {
     return `${req.get('X-Forwarded-Proto')}://${req.get('X-Forwarded-Host')}`
   }
 

--- a/tests/system/test-api-get-root.js
+++ b/tests/system/test-api-get-root.js
@@ -1,5 +1,7 @@
 const test = require('ava')
 const { deleteAllIndices } = require('../helpers/es')
+const { randomId } = require('../helpers/utils')
+const { startApi } = require('../helpers/api')
 const systemTests = require('../helpers/system-tests')
 
 test.before(async (t) => {
@@ -40,4 +42,58 @@ test('GET / returns a compressed response', async (t) => {
   const response = await t.context.api.client.get('', { resolveBodyOnly: false })
 
   t.is(response.headers['content-encoding'], 'gzip')
+})
+
+test('GET / returns links with the correct endpoint when the API was started with STAC_API_URL set', async (t) => {
+  const before = { ...process.env }
+  let api
+  try {
+    const url = `http://${randomId()}.local`
+
+    process.env['STAC_API_URL'] = url
+
+    api = await startApi()
+
+    const response = await api.client.get('')
+
+    const apiLink = response.links.find((l) => l.rel === 'service-desc')
+
+    t.not(apiLink, undefined)
+    t.is(apiLink.href, `${url}/api`)
+  } finally {
+    await api.close()
+    process.env = before
+  }
+})
+
+test('GET / returns links with the correct endpoint if `X-Forwarded-Proto` and `X-Forwarded-Host` are set', async (t) => {
+  const proto = randomId()
+  const host = randomId()
+
+  const response = await t.context.api.client.get('', {
+    headers: {
+      'X-Forwarded-Proto': proto,
+      'X-Forwarded-Host': host
+    }
+  })
+
+  const apiLink = response.links.find((l) => l.rel === 'service-desc')
+
+  t.not(apiLink, undefined)
+  t.is(apiLink.href, `${proto}://${host}/api`)
+})
+
+test.only('GET / returns links with the correct endpoint if `X-STAC-Endpoint` is set', async (t) => {
+  const url = `http://${randomId()}.local`
+
+  const response = await t.context.api.client.get('', {
+    headers: {
+      'X-STAC-Endpoint': url
+    }
+  })
+
+  const apiLink = response.links.find((l) => l.rel === 'service-desc')
+
+  t.not(apiLink, undefined)
+  t.is(apiLink.href, `${url}/api`)
 })


### PR DESCRIPTION
Closes #130

If a client includes the header `X-STAC-Endpoint`, that value will be used as the STAC endpoint when building link hrefs. The previous implementation was not particularly flexible, and could not handle the case where a client needed the link hrefs to use `http` for the schema. (This was an issue for running against a local stac instance.)