### PR TITLE
fix bbox parameter validation and "type" field in root catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Search limit parameter is now validated to be between 1 and 10000 inclusive
 - Search datetime parameter is now strictly validated as a RFC 3339 datetime or interval of two datetimes
 - Added `root` link relation to Landing Page (`/`)
+- GET /search only accepts a bbox value of a comma-separated string and POST /search
+  only accepts a bbox array of numbers. Previously, both methods accepted both formats in
+  violation of the STAC API spec.
 
 ### Changed
 

--- a/tests/fixtures/landsat-8-l1-collection.json
+++ b/tests/fixtures/landsat-8-l1-collection.json
@@ -1,5 +1,6 @@
 {
     "id": "landsat-8-l1",
+    "type": "Collection",
     "stac_version": "1.0.0",
     "description": "Landat-8 L1 Collection-1 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "links": [

--- a/tests/fixtures/stac/collection.json
+++ b/tests/fixtures/stac/collection.json
@@ -1,5 +1,6 @@
 {
     "id": "landsat-8-l1",
+    "type": "Collection",
     "stac_version": "1.0.0",
     "description": "Landat-8 L1 Collection-1 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "links": [

--- a/tests/fixtures/stac/collection2.json
+++ b/tests/fixtures/stac/collection2.json
@@ -1,5 +1,6 @@
 {
     "id": "collection2",
+    "type": "Collection",
     "stac_version": "1.0.0",
     "description": "Landat-8 L1 Collection-1 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "links": [

--- a/tests/fixtures/stac/collectionNoChildren.json
+++ b/tests/fixtures/stac/collectionNoChildren.json
@@ -254,5 +254,6 @@
         "landsat"
     ],
     "title": "Landsat 8 L1",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "type": "Collection"
 }

--- a/tests/unit/test-api-bbox.js
+++ b/tests/unit/test-api-bbox.js
@@ -10,7 +10,7 @@ test('extractBboxNull', (t) => {
 
 test('extractBbox JSON array', (t) => {
   const params = { bbox: [0, 0, 1, 1] }
-  const intersectsGeometry = api.extractBbox(params)
+  const intersectsGeometry = api.extractBbox(params, 'POST')
   t.is(intersectsGeometry.coordinates[0].length, 5)
   t.is(intersectsGeometry.coordinates[0][0][0], 0)
 })
@@ -42,11 +42,11 @@ test('extractBbox invalid bbox values', (t) => {
 
   for (const bbox of invalidBboxes) {
     t.throws(() => {
-      api.extractBbox({ bbox })
+      api.extractBbox({ bbox }, 'POST')
     }, { instanceOf: api.ValidationError })
 
     t.throws(() => {
-      api.extractBbox({ bbox: bbox.join(',') })
+      api.extractBbox({ bbox: bbox.join(',') }, 'GET')
     }, { instanceOf: api.ValidationError })
   }
 })


### PR DESCRIPTION

**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. fix bbox parameter validation so GET /search only accepts CSV string and POST /search only accepts array of numbers
2. fix type field in collection fixtures and root catalog

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
