### PR TITLE
change proj:centroid and proj:geometry to not have type match on string

### DIFF
--- a/fixtures/dynamicTemplates.js
+++ b/fixtures/dynamicTemplates.js
@@ -31,14 +31,12 @@ const templates = [
   },
   {
     proj_centroid: {
-      match_mapping_type: 'string',
       match: 'proj:centroid',
       mapping: { type: 'geo_point' }
     }
   },
   {
     proj_geometry: {
-      match_mapping_type: 'string',
       match: 'proj:geometry',
       mapping: { type: 'geo_shape' }
     }


### PR DESCRIPTION
**Related Issue(s):** 

- #235 


**Proposed Changes:**

1. remove match requirement of string for these fields, since that would never match

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
