### PR TITLE
replace constant_score and must with bool and filter for ES queries

### DIFF
--- a/src/lib/es.js
+++ b/src/lib/es.js
@@ -72,11 +72,11 @@ function buildQuery(parameters) {
   const eq = 'eq'
   const inop = 'in'
   const { query, intersects, collections, ids } = parameters
-  let must = []
+  let filterQueries = []
   if (query) {
     // Using reduce rather than map as we don't currently support all
     // stac query operators.
-    must = Object.keys(query).reduce((accumulator, property) => {
+    filterQueries = Object.keys(query).reduce((accumulator, property) => {
       const operatorsObject = query[property]
       const operators = Object.keys(operatorsObject)
       if (operators.includes(eq)) {
@@ -99,11 +99,11 @@ function buildQuery(parameters) {
         accumulator.push(rangeQuery)
       }
       return accumulator
-    }, must)
+    }, filterQueries)
   }
 
   if (ids) {
-    must.push({
+    filterQueries.push({
       terms: {
         id: ids
       }
@@ -111,7 +111,7 @@ function buildQuery(parameters) {
   }
 
   if (collections) {
-    must.push({
+    filterQueries.push({
       terms: {
         collection: collections
       }
@@ -119,7 +119,7 @@ function buildQuery(parameters) {
   }
 
   if (intersects) {
-    must.push({
+    filterQueries.push({
       geo_shape: {
         geometry: { shape: intersects }
       }
@@ -132,14 +132,16 @@ function buildQuery(parameters) {
   }
 
   if (datetimeQuery) {
-    must.push(datetimeQuery)
+    filterQueries.push(datetimeQuery)
   }
 
-  const filter = { bool: { must } }
-  const queryBody = {
-    constant_score: { filter }
+  return {
+    query: {
+      bool: {
+        filter: filterQueries
+      }
+    }
   }
-  return { query: queryBody }
 }
 
 function buildIdQuery(id) {

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -264,6 +264,15 @@ test('/search in query', async (t) => {
   t.is(response.features.length, 3)
 })
 
+test('/search limit only', async (t) => {
+  const response = await t.context.api.client.post('search', {
+    json: {
+      limit: 1
+    }
+  })
+  t.is(response.features.length, 1)
+})
+
 test('/search limit next query', async (t) => {
   let response = await t.context.api.client.post('search', {
     json: {

--- a/tests/unit/test-es.js
+++ b/tests/unit/test-es.js
@@ -12,12 +12,12 @@ test('search id parameter doesnt override other parameters', async (t) => {
 
   // TODO: the ordering here is fragile. helper methods needed to ensure the queries are correct
   t.is(
-    searchBody.body.query.constant_score.filter.bool.must[0].terms.id,
+    searchBody.body.query.bool.filter[0].terms.id,
     ids,
     'query contains id filter'
   )
   t.assert(
-    searchBody.body.query.constant_score.filter.bool.must[1].range['properties.datetime'],
+    searchBody.body.query.bool.filter[1].range['properties.datetime'],
     'query contains datetime filter'
   )
 })


### PR DESCRIPTION
**Related Issue(s):** 

- #243 


**Proposed Changes:**

1. instead of using `constant_score` and `must`, use `bool` and `filter`. This is a more typical way to express these queries, since they are filtering (similarly to how SQL select works) rather than doing scored sorting (the default ES way). 
2. using `filter` also allows these query results to be cached on the ES side, so performance will be better.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
