### PR TITLE
remove dependency on geojson-validation because it's LGPL 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - ItemCollection results no longer have a `prev` link relation. This is a by-product of changing
   pagination to use Elasticsearch's more performant `search_after` mechanism rather than `page`
 - Pagination works past 10,000 items now
+- An invalid search `intersects` parameter may sometimes return a 500 instead of a 400 status code.
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "express": "^4.17.3",
-        "geojson-validation": "^0.2.1",
         "got": "^11.0.0",
         "http-errors": "^2.0.0",
         "lodash": "^4.17.21",
@@ -8645,14 +8644,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/geojson-validation": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-validation/-/geojson-validation-0.2.1.tgz",
-      "integrity": "sha512-vcWNJ0HKF4XN5GjyCnDImeuVFwI20iBrbMYaTeS7KJqjN+UjULpi8wbRBp+8UCiy9ofetKhxKC9rH/9RdFiaJQ==",
-      "bin": {
-        "gjv": "bin/gjv"
       }
     },
     "node_modules/get-caller-file": {
@@ -26811,11 +26802,6 @@
           }
         }
       }
-    },
-    "geojson-validation": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-validation/-/geojson-validation-0.2.1.tgz",
-      "integrity": "sha512-vcWNJ0HKF4XN5GjyCnDImeuVFwI20iBrbMYaTeS7KJqjN+UjULpi8wbRBp+8UCiy9ofetKhxKC9rH/9RdFiaJQ=="
     },
     "get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.17.3",
-    "geojson-validation": "^0.2.1",
     "got": "^11.0.0",
     "http-errors": "^2.0.0",
     "lodash": "^4.17.21",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,4 @@
 const { pickBy, assign, get: getNested } = require('lodash')
-const gjv = require('geojson-validation')
 const extent = require('@mapbox/extent')
 const { DateTime } = require('luxon')
 const { isIndexNotFoundError } = require('./es')
@@ -31,16 +30,12 @@ const extractIntersects = function (params) {
       geojson = { ...intersects }
     }
 
-    if (gjv.valid(geojson)) {
-      if (geojson.type === 'FeatureCollection' || geojson.type === 'Feature') {
-        throw new Error(
-          'Expected GeoJSON geometry, not Feature or FeatureCollection'
-        )
-      }
-      intersectsGeometry = geojson
-    } else {
-      throw new ValidationError('Invalid GeoJSON geometry')
+    if (geojson.type === 'FeatureCollection' || geojson.type === 'Feature') {
+      throw new Error(
+        'Expected GeoJSON geometry, not Feature or FeatureCollection'
+      )
     }
+    intersectsGeometry = geojson
   }
   return intersectsGeometry
 }

--- a/tests/unit/test-api-extractIntersects.js
+++ b/tests/unit/test-api-extractIntersects.js
@@ -1,6 +1,4 @@
 const test = require('ava')
-const sinon = require('sinon')
-const proxyquire = require('proxyquire')
 const api = require('../../src/lib/api')
 
 test('extractIntersectsNull', (t) => {
@@ -10,25 +8,9 @@ test('extractIntersectsNull', (t) => {
     'Returns undefined when no intersects parameter')
 })
 
-test('extractIntersects', (t) => {
-  const valid = sinon.stub().returns(false)
-  const proxyApi = proxyquire('../../src/lib/api', {
-    'geojson-validation': { valid }
-  })
-  t.throws(() => {
-    proxyApi.extractIntersects({ intersects: {} })
-  },
-  { instanceOf: Error, message: 'Invalid GeoJSON geometry' },
-  'Throws exception when GeoJSON is invalid')
-})
-
 test('extractIntersects FeatureCollection', (t) => {
-  const valid = sinon.stub().returns(true)
-  const proxyApi = proxyquire('../../src/lib/api', {
-    'geojson-validation': { valid }
-  })
   t.throws(() => {
-    proxyApi.extractIntersects({
+    api.extractIntersects({
       intersects: { type: 'FeatureCollection' }
     })
   },


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/246


**Proposed Changes:**

1. remove geoson-validation library because it is LGPL 3
2. follow on issue to resolve b/c of this change is 
- https://github.com/stac-utils/stac-server/issues/245

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
