### PR TITLE
Allow use of STAC_API_ROOTPATH to set an api gw stage path prefix

### DIFF
--- a/src/lambdas/api/middleware/add-endpoint.js
+++ b/src/lambdas/api/middleware/add-endpoint.js
@@ -16,7 +16,7 @@ const determineEndpoint = (req) => {
 
   if (process.env['STAC_API_URL']) return process.env['STAC_API_URL']
 
-  const rootPath = process.env['STAC_API_ROOTPATH'] || ""
+  const rootPath = process.env['STAC_API_ROOTPATH'] || ''
 
   if (req.get('X-Forwarded-Proto') && req.get('X-Forwarded-Host')) {
     return `${req.get('X-Forwarded-Proto')}://${req.get('X-Forwarded-Host')}${rootPath}`

--- a/src/lambdas/api/middleware/add-endpoint.js
+++ b/src/lambdas/api/middleware/add-endpoint.js
@@ -16,7 +16,7 @@ const determineEndpoint = (req) => {
 
   if (process.env['STAC_API_URL']) return process.env['STAC_API_URL']
 
-  rootPath = process.env['STAC_API_ROOTPATH'] ? process.env['STAC_API_ROOTPATH'] : ""
+  const rootPath = process.env['STAC_API_ROOTPATH'] || ""
 
   if (req.get('X-Forwarded-Proto') && req.get('X-Forwarded-Host')) {
     return `${req.get('X-Forwarded-Proto')}://${req.get('X-Forwarded-Host')}${rootPath}`

--- a/src/lambdas/api/middleware/add-endpoint.js
+++ b/src/lambdas/api/middleware/add-endpoint.js
@@ -16,13 +16,16 @@ const determineEndpoint = (req) => {
 
   if (process.env['STAC_API_URL']) return process.env['STAC_API_URL']
 
+  process.env['STAC_API_ROOTPATH'] ?
+    rootPath = process.env['STAC_API_ROOTPATH'] : rootPath = ""
+
   if (req.get('X-Forwarded-Proto') && req.get('X-Forwarded-Host')) {
-    return `${req.get('X-Forwarded-Proto')}://${req.get('X-Forwarded-Host')}`
+    return `${req.get('X-Forwarded-Proto')}://${req.get('X-Forwarded-Host')}${rootPath}`
   }
 
   return req.event && req.event.requestContext && req.event.requestContext.stage
     ? `${req.get('X-Forwarded-Proto')}://${req.get('Host')}/${req.event.requestContext.stage}`
-    : `${req.get('X-Forwarded-Proto')}://${req.get('Host')}`
+    : `${req.get('X-Forwarded-Proto')}://${req.get('Host')}${rootPath}`
 }
 
 /**

--- a/src/lambdas/api/middleware/add-endpoint.js
+++ b/src/lambdas/api/middleware/add-endpoint.js
@@ -16,8 +16,7 @@ const determineEndpoint = (req) => {
 
   if (process.env['STAC_API_URL']) return process.env['STAC_API_URL']
 
-  process.env['STAC_API_ROOTPATH'] ?
-    rootPath = process.env['STAC_API_ROOTPATH'] : rootPath = ""
+  rootPath = process.env['STAC_API_ROOTPATH'] ? process.env['STAC_API_ROOTPATH'] : ""
 
   if (req.get('X-Forwarded-Proto') && req.get('X-Forwarded-Host')) {
     return `${req.get('X-Forwarded-Proto')}://${req.get('X-Forwarded-Host')}${rootPath}`


### PR DESCRIPTION
**Related Issue(s):** 

- #238 


**Proposed Changes:**

1.  Allow use of STAC_API_ROOTPATH to set an api gw stage path prefix  when STAC_API_URL is not set

**PR Checklist:**

- [ ] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
