### PR TITLE
Added mappings for default sort keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2022-06-07
+
+### Added
+
+- Added mappings for 'id' and 'collection' for default sort keys
+
 ## [0.5.0] - 2022-06-01
 
 ### Changed

--- a/fixtures/items.js
+++ b/fixtures/items.js
@@ -8,6 +8,8 @@ module.exports = {
       geometry: { type: 'geo_shape' },
       assets: { type: 'object', enabled: false },
       links: { type: 'object', enabled: false },
+      id: { type: 'keyword' },
+      collection: { type: 'keyword' },
       properties: {
         type: 'object',
         properties: {


### PR DESCRIPTION
**Related Issue(s):** 

- # https://github.com/stac-utils/stac-server/issues/249

**Proposed Changes:**

1. Added mapping within index for the default sort keys of 'id' and 'collection' 

**PR Checklist:**

- [ ] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) 
