### PR TITLE
when no collections exist, handle ES error instead of returning 500

### DIFF
--- a/src/lib/es.js
+++ b/src/lib/es.js
@@ -341,13 +341,17 @@ async function getCollection(collectionId) {
 
 // get all collections
 async function getCollections(page = 1, limit = 100) {
-  const response = await esQuery({
-    index: COLLECTIONS_INDEX,
-    size: limit,
-    from: (page - 1) * limit
-  })
-  const results = response.body.hits.hits.map((r) => (r._source))
-  return results
+  try {
+    const response = await esQuery({
+      index: COLLECTIONS_INDEX,
+      size: limit,
+      from: (page - 1) * limit
+    })
+    return response.body.hits.hits.map((r) => (r._source))
+  } catch (e) {
+    logger.error(`Failure getting collections, maybe none exist? ${e}`)
+  }
+  return []
 }
 
 async function constructSearchParams(parameters, page, limit) {


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/298


**Proposed Changes:**

1. fix error handling when no collections exist so the API is still rendered, rather than throwing a 500 error. This always happens before any items have been ingested, and gives an unclear picture as to whether a new server has deployed correctly.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
