### PR TITLE
fix a few packages that weren't updated during the node 16 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,14 +27,14 @@
       },
       "devDependencies": {
         "@stoplight/spectral-cli": "^6.2.1",
-        "@tsconfig/node14": "^1.0.1",
+        "@tsconfig/node16": "^1.0.1",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
         "@types/http-errors": "^1.8.2",
         "@types/luxon": "^2.0.9",
         "@types/memorystream": "^0.3.0",
         "@types/morgan": "^1.9.3",
-        "@types/node": "^14.18.12",
+        "@types/node": "^16.11.7",
         "@types/sinon": "^10.0.11",
         "ava": "^4.0.1",
         "aws-event-mocks": "^0.0.0",
@@ -2276,10 +2276,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
@@ -2453,9 +2453,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
+      "version": "16.18.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+      "integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -19328,10 +19328,10 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/aws-lambda": {
@@ -19505,9 +19505,9 @@
       }
     },
     "@types/node": {
-      "version": "14.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
+      "version": "16.18.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+      "integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw=="
     },
     "@types/qs": {
       "version": "6.9.7",

--- a/package.json
+++ b/package.json
@@ -61,14 +61,14 @@
     "zod": "^3.17.3"
   },
   "devDependencies": {
-    "@tsconfig/node14": "^1.0.1",
+    "@tsconfig/node16": "^1.0.1",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/http-errors": "^1.8.2",
     "@types/luxon": "^2.0.9",
     "@types/memorystream": "^0.3.0",
     "@types/morgan": "^1.9.3",
-    "@types/node": "^14.18.12",
+    "@types/node": "^16.11.7",
     "@types/sinon": "^10.0.11",
     "ava": "^4.0.1",
     "aws-event-mocks": "^0.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "alwaysStrict": true,
     "strict": true,


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. fix a few dependency versions that weren't updated from 14 to 16 when the node version was bumped


**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
