### PR TITLE
limit above max no error

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -81,10 +81,13 @@ const extractLimit = function (params) {
       throw new ValidationError('Invalid limit value')
     }
 
-    if (Number.isNaN(limit) || limit <= 0 || limit > 10000) {
+    if (Number.isNaN(limit) || limit <= 0) {
       throw new ValidationError(
         'Invalid limit value, must be a number between 1 and 10000 inclusive'
       )
+    }
+    if (limit > 10000) {
+      limit = 10000
     }
     return limit
   }

--- a/tests/unit/test-api-limit.js
+++ b/tests/unit/test-api-limit.js
@@ -9,8 +9,12 @@ test('extractLimit when set', (t) => {
   t.is(api.extractLimit({ limit: '1' }), 1)
 })
 
+test('extractLimit when over max limit', (t) => {
+  t.is(api.extractLimit({ limit: '10001' }), 10000)
+})
+
 test('extractLimit invalid values', (t) => {
-  const invalidLimits = ['', '-1', '0', '10001', 'a', -1, 0, 10001]
+  const invalidLimits = ['', '-1', '0', 'a', -1, 0]
 
   for (const limit of invalidLimits) {
     t.throws(() => {


### PR DESCRIPTION
**Related Issue(s):** 

- #312 


**Proposed Changes:**

1. a limit over 10000 will act as if the limit was 10000, instead of returning a 400. This is a recent change the the STAC API spec.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
