### PR TITLE
Fix a typo in a variable name

### DIFF
--- a/src/lib/es.js
+++ b/src/lib/es.js
@@ -33,8 +33,8 @@ function buildRangeQuery(property, operators, operatorsObject) {
     // All operators for a property go in a single range query.
     comparisons.forEach((comparison) => {
       if (operators.includes(comparison)) {
-        const exisiting = rangeQuery.range[propertyKey]
-        rangeQuery.range[propertyKey] = { ...exisiting, [comparison]: operatorsObject[comparison] }
+        const existing = rangeQuery.range[propertyKey]
+        rangeQuery.range[propertyKey] = { ...existing, [comparison]: operatorsObject[comparison] }
       }
     })
   }


### PR DESCRIPTION
**Related Issue(s):** 

- N/A


**Proposed Changes:**

1. Fix typo in variable name: `exisiting` -> `existing`

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
