### PR TITLE
add search links in root fro both GET and POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Landing Page (root) now has links for both GET and POST methods of search link relation
 - The STAC API version is now 1.0.0-rc.2
 - AWS OpenSearch Service OpenSearch 2.3 is used as the default instead of Elasticsearch 7.10.
   See [migration section in README.md](README.md#04x---05x).

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -585,7 +585,14 @@ const getCatalog = async function (txnEnabled, backend, endpoint = '') {
     {
       rel: 'search',
       type: 'application/geo+json',
-      href: `${endpoint}/search`
+      href: `${endpoint}/search`,
+      method: 'GET',
+    },
+    {
+      rel: 'search',
+      type: 'application/geo+json',
+      href: `${endpoint}/search`,
+      method: 'POST',
     },
     {
       rel: 'service-desc',


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. Add both GET and POST search link relations to root (landing page). This is how an API advertises it supports both GET and POST to the /search endpoint. 

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
