### PR TITLE
Add support for fine-grained access control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Adds support for authenticating to OpenSearch with a username and password when
+  fine-grained access control is enabled.
 - Added pre-hook and post-hook Lambda examples
 - POST /collections endpoint to create collections
 
 ### Changed
 
+- ES_HOST variable is now OPENSEARCH_HOST, but both will work for now.
+- ES_BATCH_SIZE variable is now INGEST_BATCH_SIZE. Both will work. It is recommended not to
+  configure this explicitly if not changing the value from the default of 500.
 - Landing Page (root) now has links for both GET and POST methods of search link relation
 - The STAC API version is now 1.0.0-rc.2
 - AWS OpenSearch Service OpenSearch 2.3 is used as the default instead of Elasticsearch 7.10.
@@ -30,6 +35,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade serverless to 3.x
 - Remove use of serverless-psuedo-parameters
 - Upgrade to Node 16
+
+### Deprecated
+
+- ES_BATCH_SIZE variable (replaced by INGEST_BATCH_SIZE)
+- ES_HOST variable (replaced by OPENSEARCH_HOST variable)
 
 ## [0.4.1] - 2022-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   STAC API spec several versions ago, in favor of the conformance classes.
 - STAC_API_VERSION environment variable is no longer supported. The version is now hard-coded
   to 1.0.0-rc.2
+- `lambdaHashingVersion: 20201221` is now the default for serverless, and has been removed
+  from the serverless example config file.
 
 ### Added
 

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -13,9 +13,8 @@ provider:
     STAC_TITLE: "STAC API"
     STAC_DESCRIPTION: "A STAC API using stac-server"
     LOG_LEVEL: DEBUG
-    ES_BATCH_SIZE: 500
     STAC_DOCS_URL: https://stac-utils.github.io/stac-server/
-    ES_HOST:
+    OPENSEARCH_HOST:
       Fn::GetAtt: [OpenSearchInstance, DomainEndpoint]
     ENABLE_TRANSACTIONS_EXTENSION: false
     # comment STAC_API_ROOTPATH if deployed with a custom domain

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -44,7 +44,6 @@ provider:
         #   Action: "lambda:InvokeFunction"
         #   Resource: "arn:aws:lambda:${aws:region}:${aws:accountId}:function:${self:service}-${self:provider.stage}-postHook"
 
-  lambdaHashingVersion: 20201221
 package:
   individually: true
 
@@ -140,7 +139,7 @@ resources:
       UpdatePolicy:
         EnableVersionUpgrade: true
       Properties:
-        DomainName: ${self:service}-${self:provider.stage}-os
+        DomainName: ${self:service}-${self:provider.stage}
         EBSOptions:
           EBSEnabled: true
           VolumeType: gp3

--- a/src/lib/es.js
+++ b/src/lib/es.js
@@ -10,7 +10,7 @@ const isIndexNotFoundError = (e) => (
 
 /*
 This module is used for connecting to a search database instance, writing records,
-searching records, and managing the indexes. It looks for the ES_HOST environment
+searching records, and managing the indexes. It looks for the OPENSEARCH_HOST environment
 variable which is the URL to the search database host
 */
 
@@ -235,16 +235,16 @@ async function indexCollection(collection) {
     await esClient.createIndex(COLLECTIONS_INDEX)
   }
 
-  await client.index({
+  const collectionDocResponse = await client.index({
     index: COLLECTIONS_INDEX,
     id: collection.id,
     body: collection,
     opType: 'create'
   })
 
-  const response = await esClient.createIndex(collection.id)
+  const indexCreateResponse = await esClient.createIndex(collection.id)
 
-  return response
+  return [collectionDocResponse, indexCreateResponse]
 }
 
 /*
@@ -366,9 +366,8 @@ async function constructSearchParams(parameters, page, limit) {
     body.search_after = buildSearchAfter(parameters)
   }
 
-  // Specifying the scroll parameter makes the total work
   const searchParams = {
-    index: collections || '*,-*kibana*,-collections',
+    index: collections || '*,-.*,-collections',
     body,
     size: limit,
     track_total_hits: true

--- a/src/lib/esStream.js
+++ b/src/lib/esStream.js
@@ -142,7 +142,7 @@ async function stream() {
 
     const esStream = new SearchDatabaseWritableStream({ client: client }, {
       objectMode: true,
-      highWaterMark: Number(process.env.ES_BATCH_SIZE) || 500
+      highWaterMark: Number(process.env.INGEST_BATCH_SIZE || process.env.ES_BATCH_SIZE) || 500
     })
     esStreams = { toEs, esStream }
   } catch (error) {


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/316


**Proposed Changes:**

1. Add support for fine-grained access control, where stac-server must authenticate to OpenSearch with a username and password, rather than getting full access via IAM permissions. This username and password can be stored as a Secrets Manager secret and retrieved by ARN
2. Rename ES_HOST and ES_BATCH_SIZE variables (with backwards compatibility)
3. Change the search's index restriction to also cover the "dot" indices created by opensearch

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
