### PR TITLE
ava should use a cmdline flag to serialize integration tests rather than the deprecated 'serial' config property

### DIFF
--- a/bin/system-tests.sh
+++ b/bin/system-tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TEST_PATTERN=${1:-test-*.js}
+TEST_PATTERN=${1:-test-*.[jt]s}
 
 export AWS_ACCESS_KEY_ID='none'
 export AWS_SECRET_ACCESS_KEY='none'
@@ -10,7 +10,7 @@ export ENABLE_TRANSACTIONS_EXTENSION=true
 
 echo "Running tests"
 set +e
-npx ava "./tests/system/${TEST_PATTERN}"
+npx ava "./tests/system/${TEST_PATTERN}" --serial
 TEST_RESULT="$?"
 set -e
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     ]
   },
   "ava": {
-    "verbose": true,
-    "serial": true
+    "verbose": true
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. run system tests with `--serial` flag rather than using deprecated ava config file param

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
