### PR TITLE
auth pre-hook: change expected value for secrets manager secret from string to array, require write permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ To enable this example pre-hook:
 - In the serverless.yml file, uncomment the `preHook` function, the `preHook` IAM
   permissions, and the environment variables `PRE_HOOK` and `API_KEYS_SECRET_ID`
 - Create a Secrets Manager secret with the name used in `API_KEYS_SECRET_ID` with
-  the keys as the strings allowed for API Keys and the values as `read`.
+  the keys as the strings allowed for API Keys and the values as an array `["write"]`.
 - Build and deploy.
 
 ### Post-Hook

--- a/src/lambdas/pre-hook/index.js
+++ b/src/lambdas/pre-hook/index.js
@@ -13,7 +13,7 @@ const response401 = {
 }
 
 // eslint-disable-next-line import/no-mutable-exports
-export let apiKeys = new Map()
+export let apiKeys = new Map() // string -> string[]
 
 const updateApiKeys = async () => {
   await new SecretsManagerClient({ region: process.env['AWS_REGION'] || 'us-west-2' })
@@ -35,8 +35,7 @@ const updateApiKeys = async () => {
     })
 }
 
-const READ = ['read']
-const isValidReadToken = (token) => READ.includes(apiKeys.get(token))
+const isValidToken = (token) => (apiKeys.get(token) || []).includes('write')
 
 export const handler = async (event, _context) => {
   let token = null
@@ -54,7 +53,7 @@ export const handler = async (event, _context) => {
     await updateApiKeys()
   }
 
-  if (isValidReadToken(token)) {
+  if (isValidToken(token)) {
     return event
   }
 

--- a/tests/unit/test-pre-hook.js
+++ b/tests/unit/test-pre-hook.js
@@ -90,7 +90,7 @@ test.serial('authenticate cases', async (t) => {
     // @ts-ignore
     .on(GetSecretValueCommand)
     // @ts-ignore
-    .resolves({ SecretString: JSON.stringify({ ABC: 'read', DEF: 'other' }) })
+    .resolves({ SecretString: JSON.stringify({ ABC: ['write'], DEF: ['other'] }) })
 
   const event = { ...DEFAULT_EVENT }
   const context = { ...DEFAULT_CONTEXT }


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. change expected secrets value for auth pre-hook from a string to an array.
2. Change the default permission required to "write" until conditional logic that checks the verb and path can be implemented

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
