### PR TITLE
fix run serve script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "audit-prod": "npx better-npm-audit audit --production",
     "deploy": "sls deploy",
     "package": "sls package",
-    "serve": "REQUEST_LOGGING_FORMAT=dev LOG_LEVEL=debug STAC_API_URL=http://localhost:3000 ENABLE_TRANSACTIONS_EXTENSION=true nodemon ./src/lambdas/api/local.ts",
+    "serve": "REQUEST_LOGGING_FORMAT=dev LOG_LEVEL=debug STAC_API_URL=http://localhost:3000 ENABLE_TRANSACTIONS_EXTENSION=true nodemon --esm ./src/lambdas/api/local.ts",
     "build-api-docs": "npm run widdershins --search false --language_tabs 'nodejs:NodeJS' 'python:Python' --summary ./packages/api-lib/api-spec.yaml -o ./docs/api.md & npm run shins --inline --logo ./docs/images/logo.png -o ./docs/index.html ./docs/api.md",
     "pre-commit": "./node_modules/pre-commit/hook"
   },

--- a/src/lambdas/api/local.ts
+++ b/src/lambdas/api/local.ts
@@ -1,5 +1,5 @@
 import winston from 'winston'
-import { app } from './app'
+import { app } from './app.js'
 
 const logger = winston.createLogger({
   level: process.env['LOG_LEVEL'] || 'warn',


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. Fix `serve` script by correctly importing the app in local.ts and enabling ESM module support in nodemon 

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
