### PR TITLE
use storage:region for thumbnail generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,8 @@ Initial release, forked from [sat-api](https://github.com/sat-utils/sat-api/tree
 
 Compliant with STAC 0.9.0
 
+[0.8.1]: https://github.com/stac-utils/stac-api/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/stac-utils/stac-api/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/stac-utils/stac-api/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/stac-utils/stac-api/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/stac-utils/stac-api/compare/v0.4.1...v0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - TBD
+## [0.8.1] - 2023-03-29
+
+### Added
+
+- Thumbnail support will now look at Asset or Item level `storage:region` field
+  to determine the region for generating the pre-signed URL for the thumbnail.
+  Previously used the default behavior of AWS SDK.
+
+## [0.8.0] - 2023-03-06
 
 ### Added
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -920,10 +920,14 @@ const getItemThumbnail = async function (collectionId, itemId, backend) {
   if (thumbnailAsset.href && thumbnailAsset.href.startsWith('http')) {
     location = thumbnailAsset.href
   } else if (thumbnailAsset.href && thumbnailAsset.href.startsWith('s3')) {
+    const region = thumbnailAsset['storage:region']
+                  || item.properties['storage:region']
+                  || process.env['AWS_REGION']
+                  || 'us-west-2'
     const withoutProtocol = thumbnailAsset.href.substring(5) // chop off s3://
     const [bucket, ...keyArray] = withoutProtocol.split('/')
     const key = keyArray.join('/')
-    location = new AWS.S3().getSignedUrl('getObject', {
+    location = new AWS.S3({ region }).getSignedUrl('getObject', {
       Bucket: bucket,
       Key: key,
       Expires: 60 * 5, // expiry in seconds


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. Use `storage:region` field for determining which region thumbnail URLs should be generated against.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
