### PR TITLE
update to default to OpenSearch 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - TBD
+
+### Changed
+
+- Updated example serverless configuration to use OpenSearch 2.5.
+
 ## [0.8.1] - 2023-03-29
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.3.0
+    image: opensearchproject/opensearch:2.5.0
     ports:
       - "127.0.0.1:9200:9200"
       - "127.0.0.1:9300:9300"

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -154,7 +154,7 @@ resources:
           InstanceCount: 1
           DedicatedMasterEnabled: false
           ZoneAwarenessEnabled: false
-        EngineVersion: OpenSearch_2.3
+        EngineVersion: OpenSearch_2.5
         DomainEndpointOptions:
           EnforceHTTPS: true
   Outputs:


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/429


**Proposed Changes:**

1. Update default OpenSearch version used by deployment to 2.5. (Note: the opensearch client library does not need to be updated to use this new version, and there is no newer version of it)

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
