### PR TITLE
add stac_version to the default fields returned when that parameter is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Updated example serverless configuration to use OpenSearch 2.5.
+- Added `stac_version` to the default set of fields returned when the `fields` parameter
+  is an empty value.
 
 ## Added
 

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -199,6 +199,7 @@ function buildFieldsFilter(parameters) {
     _sourceIncludes = [
       'id',
       'type',
+      'stac_version',
       'geometry',
       'bbox',
       'links',

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -189,6 +189,7 @@ test('/search fields filter', async (t) => {
   t.truthy(response.features[0].bbox)
   t.truthy(response.features[0].links)
   t.truthy(response.features[0].assets)
+  t.truthy(response.features[0].stac_version)
 
   response = await t.context.api.client.post('search', {
     json: {


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/405


**Proposed Changes:**

1. Add `stac_version` to the default fields returned when the `fields` value is empty. This is a recent change to the fields extension (1.0.0-rc.3). 

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
