### PR TITLE
update conformance to STAC API 1.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated example serverless configuration to use OpenSearch 2.5.
 - Added `stac_version` to the default set of fields returned when the `fields` parameter
   is an empty value.
+- STAC API Foundation conformance classes are now 1.0.0-rc.4
+- STAC API Fields Extension conformance class is now 1.0.0-rc.3
 
 ## Removed
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,16 @@
 
 Stac-server is an implementation of the [STAC API specification](https://github.com/radiantearth/stac-api-spec) for searching and serving metadata for geospatial data, including but not limited to satellite imagery). The STAC and STAC API versions supported by a given version of stac-server are shown in the table below. Additional information can be found in the [CHANGELOG](CHANGELOG.md)
 
-| stac-server Version | STAC Version | STAC API Version |
-| ------------------- | ------------ | ---------------- |
-| 0.1.x               | 0.9.x        | 0.9.x            |
-| 0.2.x               | <1.0.0-rc.1  | 0.9.x            |
-| 0.3.x               | 1.0.0        | 1.0.0-beta.2     |
-| 0.4.x               | 1.0.0        | 1.0.0-beta.5     |
-| 0.5.x               | 1.0.0        | 1.0.0-rc.2       |
+| stac-server Version(s) | STAC Version | STAC API Foundation Version |
+| ---------------------- | ------------ | --------------------------- |
+| 0.1.x                  | 0.9.x        | 0.9.x                       |
+| 0.2.x                  | <1.0.0-rc.1  | 0.9.x                       |
+| 0.3.x                  | 1.0.0        | 1.0.0-beta.2                |
+| 0.4.x                  | 1.0.0        | 1.0.0-beta.5                |
+| 0.5.x-0.8.x            | 1.0.0        | 1.0.0-rc.2                  |
+| >=0.9.x                | 1.0.0        | 1.0.0-rc.4                  |
 
-As of version 0.5.x, stac-server supports the following specifications:
+Currently, stac-server supports the following specifications:
 
 - STAC API - Core
 - STAC API - Features
@@ -69,7 +70,7 @@ As of version 0.5.x, stac-server supports the following specifications:
 - Query Extension
 - Fields Extension
 - Sort Extension
-- Aggregation Extension (experimental work-in-progress)
+- Aggregation Extension (experimental, work-in-progress)
 
 The following APIs are deployed instances of stac-server:
 
@@ -192,7 +193,7 @@ Create a clone of the stac-server 0.5.x code. Copy and update the serverless.yml
   - `ElasticsearchVersion` is replaced with `EngineVersion` and set to `OpenSearch_2.3`
 - `EsEndpoint` should be renamed to `OpenSearchEndpoint` and the exported name suffixed
     with `-os-endpoint` instead of `-es-endpoint`
-- Environment variable `STAC_API_VERSION` should be removed to instead defer to the default version of `1.0.0-rc.2`
+- Environment variable `STAC_API_VERSION` should be removed to instead defer to the current default version
 
 You can also compare it with the serverless.example.yml file. The `DomainName` value
 **must** remain the same as it is for the current deployment so
@@ -409,8 +410,8 @@ There are some settings that should be reviewed and updated as needeed in the se
 | STAC_DOCS_URL                    | URL to documentation                                                                                                                                                                             | [https://stac-utils.github.io/stac-server](https://stac-utils.github.io/stac-server) |
 | INGEST_BATCH_SIZE                | Number of records to ingest in single batch                                                                                                                                                      | 500                                                                                  |
 | LOG_LEVEL                        | Level for logging (error, warn, info, http, verbose, debug, silly)                                                                                                                               | warn                                                                                 |
-| REQUEST_LOGGING_ENABLED                        | Express request logging enabled. String 'false' disables.                                                                                                                               | enabled                                                                                 |
-| REQUEST_LOGGING_FORMAT                        | Express request logging format to use. Any of the [Morgan predefined formats](https://github.com/expressjs/morgan#predefined-formats).                                                                                                                           | tiny                                                                                 |
+| REQUEST_LOGGING_ENABLED          | Express request logging enabled. String 'false' disables.                                                                                                                                        | enabled                                                                              |
+| REQUEST_LOGGING_FORMAT           | Express request logging format to use. Any of the [Morgan predefined formats](https://github.com/expressjs/morgan#predefined-formats).                                                           | tiny                                                                                 |
 | STAC_API_URL                     | The root endpoint of this API                                                                                                                                                                    | Inferred from request                                                                |
 | ENABLE_TRANSACTIONS_EXTENSION    | Boolean specifying if the [Transaction Extension](https://github.com/radiantearth/stac-api-spec/tree/master/ogcapi-features/extensions/transaction) should be activated                          | false                                                                                |
 | STAC_API_ROOTPATH                | The path to append to URLs if this is not deployed at the server root. For example, if the server is deployed without a custom domain name, it will have the stage name (e.g., dev) in the path. | ""                                                                                   |

--- a/bin/build-openapi.sh
+++ b/bin/build-openapi.sh
@@ -4,19 +4,17 @@ set -x # print each command before exec
 
 PATH=./node_modules/.bin:$PATH
 
-STAC_API_VERSION='v1.0.0-rc.2'
+STAC_API_VERSION='v1.0.0-rc.4'
 
 curl "https://api.stacspec.org/${STAC_API_VERSION}/core/openapi.yaml" -o core.yaml
 curl "https://api.stacspec.org/${STAC_API_VERSION}/collections/openapi.yaml" -o collections.yaml
 curl "https://api.stacspec.org/${STAC_API_VERSION}/item-search/openapi.yaml" -o item-search.yaml
 curl "https://api.stacspec.org/${STAC_API_VERSION}/ogcapi-features/openapi.yaml" -o ogcapi-features.yaml
-curl "https://api.stacspec.org/${STAC_API_VERSION}/ogcapi-features/extensions/transaction/openapi.yaml" -o ogcapi-features-txn.yaml
 
 yq eval-all '. as $item ireduce ({}; . * $item )' \
   core.yaml collections.yaml \
   ogcapi-features.yaml \
-  \ #ogcapi-features-txn.yaml \
   item-search.yaml \
   > src/lambdas/api/openapi.yaml
 
-rm core.yaml collections.yaml item-search.yaml ogcapi-features.yaml ogcapi-features-txn.yaml
+rm core.yaml collections.yaml item-search.yaml ogcapi-features.yaml

--- a/src/lambdas/api/openapi.yaml
+++ b/src/lambdas/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API
-  version: 1.0.0-rc.2
+  version: 1.0.0-rc.4
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API specification.
   contact:

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -863,26 +863,26 @@ const aggregate = async function (
 }
 
 const getConformance = async function (txnEnabled) {
-  const prefix = 'https://api.stacspec.org/v1.0.0-rc.2'
+  const foundationPrefix = 'https://api.stacspec.org/v1.0.0-rc.2'
   const conformsTo = [
-    `${prefix}/core`,
-    `${prefix}/collections`,
-    `${prefix}/ogcapi-features`,
-    `${prefix}/ogcapi-features#fields`,
-    `${prefix}/ogcapi-features#sort`,
-    `${prefix}/ogcapi-features#query`,
-    `${prefix}/item-search`,
-    `${prefix}/item-search#fields`,
-    `${prefix}/item-search#sort`,
-    `${prefix}/item-search#query`,
-    'https://api.stacspec.org/v0.2.0/aggregation',
+    `${foundationPrefix}/core`,
+    `${foundationPrefix}/collections`,
+    `${foundationPrefix}/ogcapi-features`,
+    `${foundationPrefix}/item-search`,
+    'https://api.stacspec.org/v1.0.0-rc.3/ogcapi-features#fields',
+    'https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features#sort',
+    'https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features#query',
+    'https://api.stacspec.org/v1.0.0-rc.3/item-search#fields',
+    'https://api.stacspec.org/v1.0.0-rc.2/item-search#sort',
+    'https://api.stacspec.org/v1.0.0-rc.2/item-search#query',
+    'https://api.stacspec.org/v0.3.0/aggregation',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson'
   ]
 
   if (txnEnabled) {
-    conformsTo.push(`${prefix}/ogcapi-features/extensions/transaction`)
+    conformsTo.push('https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features/extensions/transaction')
   }
 
   return { conformsTo }


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. Update "foundation" conformance classes to 1.0.0-rc.4
2. Update fields to 1.0.0-rc.3 (extensions are independently versioned from foundation now)
3. Remove transactions from published api spec, as this is no longer published in the same location.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
