### PR TITLE
1.0.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - TBD
+## [1.0.0] - 2023-04-24
 
 ### Changed
 
+- STAC API Foundation conformance classes are now 1.0.0
 - Updated example serverless configuration to use OpenSearch 2.5.
 - Added `stac_version` to the default set of fields returned when the `fields` parameter
   is an empty value.
-- STAC API Foundation conformance classes are now 1.0.0-rc.4
 - STAC API Fields Extension conformance class is now 1.0.0-rc.3
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Stac-server is an implementation of the [STAC API specification](https://github.
 | 0.3.x                  | 1.0.0        | 1.0.0-beta.2                |
 | 0.4.x                  | 1.0.0        | 1.0.0-beta.5                |
 | 0.5.x-0.8.x            | 1.0.0        | 1.0.0-rc.2                  |
-| >=0.9.x                | 1.0.0        | 1.0.0-rc.4                  |
+| 1.0.0                  | 1.0.0        | 1.0.0                       |
 
 Currently, stac-server supports the following specifications:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stac-server",
-  "version": "0.8.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stac-server",
-      "version": "0.8.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@acuris/aws-es-connection": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "stac-server",
   "description": "A STAC API running on stac-server",
-  "version": "0.8.1",
+  "version": "1.0.0",
   "repository": "https://github.com/stac-utils/stac-server",
   "author": "Alireza Jazayeri, Matthew Hanson <matt.a.hanson@gmail.com>, Sean Harkins",
   "license": "MIT",

--- a/src/lambdas/api/openapi.yaml
+++ b/src/lambdas/api/openapi.yaml
@@ -1541,7 +1541,7 @@ components:
             title: Copernicus Sentinel Imagery
             description: Catalog of Copernicus Sentinel 1 and 2 imagery.
             conformsTo:
-              - https://api.stacspec.org/v1.0.0-rc.2/core
+              - https://api.stacspec.org/v1.0.0/core
             links:
               - href: http://data.example.org/
                 rel: self

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -860,7 +860,7 @@ const aggregate = async function (
 }
 
 const getConformance = async function (txnEnabled) {
-  const foundationPrefix = 'https://api.stacspec.org/v1.0.0-rc.2'
+  const foundationPrefix = 'https://api.stacspec.org/v1.0.0'
   const conformsTo = [
     `${foundationPrefix}/core`,
     `${foundationPrefix}/collections`,


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. Update STAC API version references to 1.0.0
2. Prep for stac-server 1.0.0 release

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
