### PR TITLE
Adds API Gateway transaction ID to requests and logs immediately #458

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - 2023-05-02
+## [1.1.0] - 2023-05-02
 
 ### Changed
 - Adds API Gateway ID to cloudwatch logs.
@@ -280,6 +280,8 @@ Initial release, forked from [sat-api](https://github.com/sat-utils/sat-api/tree
 
 Compliant with STAC 0.9.0
 
+[1.1.0]: https://github.com/stac-utils/stac-api/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/stac-utils/stac-api/compare/v0.8.1...v1.0.0
 [0.8.1]: https://github.com/stac-utils/stac-api/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/stac-utils/stac-api/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/stac-utils/stac-api/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2023-05-02
+
+### Changed
+- Adds API Gateway ID to cloudwatch logs.
+- Logs the start of the request in case of Lambda timeout.
+
 ## [1.0.0] - 2023-04-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "stac-server",
   "description": "A STAC API running on stac-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": "https://github.com/stac-utils/stac-server",
   "author": "Alireza Jazayeri, Matthew Hanson <matt.a.hanson@gmail.com>, Sean Harkins",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "stac-server",
   "description": "A STAC API running on stac-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": "https://github.com/stac-utils/stac-server",
   "author": "Alireza Jazayeri, Matthew Hanson <matt.a.hanson@gmail.com>, Sean Harkins",
   "license": "MIT",

--- a/src/lambdas/api/app.js
+++ b/src/lambdas/api/app.js
@@ -22,7 +22,19 @@ const txnEnabled = process.env['ENABLE_TRANSACTIONS_EXTENSION'] === 'true'
 export const app = express()
 
 if (process.env['REQUEST_LOGGING_ENABLED'] !== 'false') {
-  app.use(morgan(process.env['REQUEST_LOGGING_FORMAT'] || 'tiny'))
+  app.use(
+    [
+      // Setting `immediate: true` allows us to log at request start
+      // in case the lambda times out it's helpful to have the request ID
+      // Using console out will allow us to capture the request ID from lambda
+      morgan('Request Start - :method :url',
+        { immediate: true, stream: { write: (message) => console.info(`${message}`) } }),
+      // Logs at the end of the request
+      // Using console out will allow us to capture the request ID from lambda
+      morgan(process.env['REQUEST_LOGGING_FORMAT'] || 'tiny',
+        { stream: { write: (message) => console.info(message) } })
+    ]
+  )
 }
 
 app.use(cors())


### PR DESCRIPTION
**Related Issue(s):** 

- [# 458](https://github.com/stac-utils/stac-server/issues/458)


**Proposed Changes:**
This commit addresses two issues:
* The current morgan implementation does not pass through the request id generated by the API Gateway, making it difficult to filter to a given bad request. By writing output to console out, we are able to capture this id as part of the log statement.
* The current morgan implementation will only log if a request is successful due to the fact that it is async, which means that if a lambda timeout is reached we will not see the request that caused the timeout. This is problematic, because as an operator, we may want to see if this timeout is reproduceable. Adding  with minimal additional output will allow us to capture the start of the request. This adds one line of logging for each request, but will hopefully assist troubleshooting.

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
