### PR TITLE
 Use the type field to determine if ingest is collection or item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Remove node streams-based ingest code to prepare for post-ingest notifications
+- Use the type field to determin if ingest is collection or item
 
 ## [1.1.0] - 2023-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Remove node streams-based ingest code to prepare for post-ingest notifications
-- Use the type field to determin if ingest is collection or item
+- Use the `type` field to determine if ingest is a Collection or Item
 
 ## [1.1.0] - 2023-05-02
 

--- a/src/lib/ingest.js
+++ b/src/lib/ingest.js
@@ -6,13 +6,13 @@ const COLLECTIONS_INDEX = process.env['COLLECTIONS_INDEX'] || 'collections'
 
 export async function convertIngestObjectToDbObject(
   // eslint-disable-next-line max-len
-  /** @type {{ hasOwnProperty: (arg0: string) => any; collection: string; links: any[]; id: any; }} */ data
+  /** @type {{ hasOwnProperty: (arg0: string) => any; type: string, collection: string; links: any[]; id: any; }} */ data
 ) {
   let index = ''
   logger.debug('data', data)
-  if (data && data.hasOwnProperty('extent')) {
+  if (data && data.type === 'Collection') {
     index = COLLECTIONS_INDEX
-  } else if (data && data.hasOwnProperty('geometry')) {
+  } else if (data && data.type === 'Feature') {
     index = data.collection
   } else {
     return null


### PR DESCRIPTION
**Related Issue(s):** 

- #486

**Proposed Changes:**

1. The `type` field is required in STAC API 1.0.0 and using that field is preferable to a heuristic based on other field values.

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
