### PR TITLE
Await SNS message publishing and replace queue purge test helper

### DIFF
--- a/src/lib/ingest.js
+++ b/src/lib/ingest.js
@@ -187,11 +187,11 @@ function updateLinksWithinRecord(record) {
   return record
 }
 
-export async function publishResultsToSns(results, topicArn) {
-  results.forEach((result) => {
+export function publishResultsToSns(results, topicArn) {
+  results.forEach(async (result) => {
     if (result.record && !result.error) {
       updateLinksWithinRecord(result.record)
     }
-    publishRecordToSns(topicArn, result.record, result.error)
+    await publishRecordToSns(topicArn, result.record, result.error)
   })
 }


### PR DESCRIPTION


**Related Issue(s):** 

- #45

**Proposed Changes:**

This commit addresses intermittent failures in system tests related to SNS message publishing. Adding console.log statements revealed 2 situations

- Test assertions were running before an item ingest message was published
- Calling `purgeQeue` did not appear to actually empty the SNS queue

This commit moves an await call to guarantee that messages are published to SNS before trying to assert that they have been published and replaces a call to `purgeQueue` will calling `receiveMessage` in a loop.

Here is an example of an intermittent test failure that lead to troubleshooting and creating this PR https://github.com/stac-utils/stac-server/actions/runs/5049084598/jobs/9058087110

These are the `console.log` messages I added to help debug this

```diff
diff --git a/tests/helpers/ingest.js b/tests/helpers/ingest.js
index bd514d2..afb216d 100644
--- a/tests/helpers/ingest.js
+++ b/tests/helpers/ingest.js
@@ -90,6 +90,14 @@ export async function testPostIngestSNS(t, record) {
     WaitTimeSeconds: 1
   }).promise()
 
+  console.log('Message count', Messages && Messages.length)
+
+  const { Messages: m2 } = await sqs().receiveMessage({
+    QueueUrl: t.context.postIngestQueueUrl,
+    WaitTimeSeconds: 1
+  }).promise()
+  console.log('m2 count', m2 && m2.length)
+
   t.truthy(Messages, 'Post-ingest message not found in queue')
   t.false(Messages && Messages.length > 1, 'More than one message in post-ingest queue')
 
```

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
