### PR TITLE
API Gateway logging example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+
+### Added
+
+- Added API Gateway logging config to example serverless.yml config.
+
 ## [2.2.0] - 2023-07-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -843,16 +843,8 @@ stac-server does not use SQL.
 ### API Gateway Logging
 
 The example serverless.yml config contains disabled configuration for setting up
-API Gateway logging of API requests, like:
-
-```yaml
-logs:
-  restApi:
-    executionLogging: false
-    fullExecutionData: false
-    accessLogging: false
-    format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","useragent" : "$context.identity.userAgent","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}'
- ```
+API Gateway logging of API requests. More information about these configuration can be
+found in the [Serverless Framework API Gateway Documentation](https://www.serverless.com/framework/docs/providers/aws/events/apigateway#logs).
 
 The `executionLogging` setting causes logging of the actual execution of the API Gateway
 endpoints and backing Lambda, with `fullExecutionData` causing the entire request and

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
     - [Proxying Stac-server through CloudFront](#proxying-stac-server-through-cloudfront)
     - [Locking down transaction endpoints](#locking-down-transaction-endpoints)
     - [AWS WAF Rule Conflicts](#aws-waf-rule-conflicts)
+    - [API Gateway Logging](#api-gateway-logging)
   - [Queryables](#queryables)
   - [Aggregation](#aggregation)
   - [Ingesting Data](#ingesting-data)
@@ -838,6 +839,27 @@ This is also triggered when using pystac_client with no filtering parameters.
 
 The fix is to disable the WAF SQL injection rule, which is unnecessary because
 stac-server does not use SQL.
+
+### API Gateway Logging
+
+The example serverless.yml config contains disabled configuration for setting up
+API Gateway logging of API requests, like:
+
+```yaml
+logs:
+  restApi:
+    executionLogging: false
+    fullExecutionData: false
+    accessLogging: false
+    format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","useragent" : "$context.identity.userAgent","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}'
+ ```
+
+The `executionLogging` setting causes logging of the actual execution of the API Gateway
+endpoints and backing Lambda, with `fullExecutionData` causing the entire request and
+response to be logged to CloudWatch, which can be expensive.
+
+The `accessLogging` setting logs the values specified in `format` to CloudWatch, which
+can be useful for computing metrics on usage for the API.
 
 ## Queryables
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typecheck": "tsc",
     "audit-prod": "npx better-npm-audit audit --production -x 1091470",
     "deploy": "sls deploy",
-    "destroy": "sls destory",
+    "destroy": "sls destroy",
     "package": "sls package",
     "serve": "REQUEST_LOGGING_FORMAT=dev LOG_LEVEL=debug STAC_API_URL=http://localhost:3000 ENABLE_TRANSACTIONS_EXTENSION=true nodemon --esm ./src/lambdas/api/local.ts",
     "build-api-docs": "npm run widdershins --search false --language_tabs 'nodejs:NodeJS' 'python:Python' --summary ./packages/api-lib/api-spec.yaml -o ./docs/api.md & npm run shins --inline --logo ./docs/images/logo.png -o ./docs/index.html ./docs/api.md",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc",
     "audit-prod": "npx better-npm-audit audit --production -x 1091470",
     "deploy": "sls deploy",
+    "destroy": "sls destory",
     "package": "sls package",
     "serve": "REQUEST_LOGGING_FORMAT=dev LOG_LEVEL=debug STAC_API_URL=http://localhost:3000 ENABLE_TRANSACTIONS_EXTENSION=true nodemon --esm ./src/lambdas/api/local.ts",
     "build-api-docs": "npm run widdershins --search false --language_tabs 'nodejs:NodeJS' 'python:Python' --summary ./packages/api-lib/api-spec.yaml -o ./docs/api.md & npm run shins --inline --logo ./docs/images/logo.png -o ./docs/index.html ./docs/api.md",

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -8,6 +8,12 @@ provider:
   # uncomment this if using a bucket that already exists for deployment files
   # deploymentBucket:
   #   name: my-deployment-bucket
+  logs:
+    restApi:
+      executionLogging: false
+      fullExecutionData: false
+      accessLogging: false
+      format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","useragent" : "$context.identity.userAgent","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}'
   environment:
     STAC_ID: "stac-server"
     STAC_TITLE: "STAC API"


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. Add example of configuring API Gateway logging

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.

This will log to a CloudWatch group named `/aws/api-gateway/{service}-{stage}`.

<img width="1060" alt="image" src="https://github.com/stac-utils/stac-server/assets/124996/7caad127-6464-4e78-96b7-293a22c11900">

