### PR TITLE
update default OpenSearch to 2.7

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: package.json
       - uses: ankane/setup-opensearch@v1
         with:
-          opensearch-version: 2.5
+          opensearch-version: 2.7
       - name: Upgrade npm
         run: npm install -g npm@latest
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+
+### Changed
+
+- Default to OpenSearch 2.7
+
 ## [2.2.3] - 2023-07-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   - [Overview](#overview)
   - [Architecture](#architecture)
   - [Migration](#migration)
+    - [2.4.x](#24x)
+      - [OpenSearch Version 2.7](#opensearch-version-27)
     - [0.x or 1.x -\> 2.x](#0x-or-1x---2x)
       - [Fine-grained Access Control](#fine-grained-access-control)
       - [Enabling Post-ingest SNS publishing](#enabling-post-ingest-sns-publishing)
@@ -128,6 +130,13 @@ apiLambda --> opensearch
 ```
 
 ## Migration
+
+### 2.4.x
+
+#### OpenSearch Version 2.7
+
+- Update the `EngineVersion` setting in the serverless config file to `OpenSearch_2.7`
+  and re-deploy
 
 ### 0.x or 1.x -> 2.x
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.5.0
+    image: opensearchproject/opensearch:2.7.0
     ports:
       - "127.0.0.1:9200:9200"
       - "127.0.0.1:9300:9300"

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -182,7 +182,7 @@ resources:
           InstanceCount: 1
           DedicatedMasterEnabled: false
           ZoneAwarenessEnabled: false
-        EngineVersion: OpenSearch_2.5
+        EngineVersion: OpenSearch_2.7
         DomainEndpointOptions:
           EnforceHTTPS: true
         NodeToNodeEncryptionOptions:


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/561


**Proposed Changes:**

1. Update default OpenSearch version to 2.7

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
