### PR TITLE
remove aws-sdk usage

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: package.json
       - uses: ankane/setup-opensearch@v1
         with:
-          opensearch-version: 2.7
+          opensearch-version: 2.11
       - name: Upgrade npm
         run: npm install -g npm@8.19.4
       - name: Install dependencies

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       localstack:
-        image: localstack/localstack
+        image: localstack/localstack:3
         env:
           SERVICES: s3,sns,sqs
         ports:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+
+### Added
+
+- Better error handling when create_index fails.
+
+### Fixed
+
+- Removed usages of aws-sdk that were missed in 3.0.0.
+
 ## [3.1.0] - 2023-11-28
 
 ### Added
@@ -386,7 +396,7 @@ Initial release, forked from [sat-api](https://github.com/sat-utils/sat-api/tree
 
 Compliant with STAC 0.9.0
 
-<!-- [Unreleased]: https://github.com/stac-utils/stac-api/compare/v2.4.0...main -->
+[Unreleased]: https://github.com/stac-utils/stac-api/compare/v2.4.0...main
 [3.1.0]: https://github.com/stac-utils/stac-api/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/stac-utils/stac-api/compare/v2.4.0...v3.0.0
 [2.4.0]: https://github.com/stac-utils/stac-api/compare/v2.3.0...v2.4.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,9 @@ services:
     volumes:
       - ./opensearch/config/opensearch.yml:/usr/share/opensearch/config/opensearch.yml
   localstack:
-    image: localstack/localstack:2.1.0
+    image: localstack/localstack:3
     ports:
-      - "127.0.0.1:4566:4566"
+      - "127.0.0.1:4566:4566" # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
       - SERVICES=s3,sns,sqs

--- a/src/lambdas/api/index.js
+++ b/src/lambdas/api/index.js
@@ -8,7 +8,7 @@
 
 import { z } from 'zod'
 import serverless from 'serverless-http'
-import { Lambda } from 'aws-sdk'
+import { Lambda } from '@aws-sdk/client-lambda'
 import { app } from './app.js'
 import _default from './types.js'
 import logger from '../../lib/logger.js'
@@ -64,26 +64,26 @@ const logZodParseError = (data, error) => {
 }
 
 /**
- * @param {any} lambda
+ * @param {Lambda} lambda
  * @param {string} preHook
  * @param {APIGatewayProxyEvent} payload
  * @returns {Promise<APIGatewayProxyEvent|APIGatewayProxyResult>}
  */
 const invokePreHook = async (lambda, preHook, payload) => {
-  /** @type {Lambda.InvocationResponse} */
+  /** @type {import("@aws-sdk/client-lambda").InvocationResponse} */
   let invocationResponse
   try {
     invocationResponse = await lambda.invoke({
       FunctionName: preHook,
       Payload: JSON.stringify(payload)
-    }).promise()
+    })
   } catch (error) {
     logger.error('Failed to invoke pre-hook lambda:', error)
     return internalServerError
   }
 
   // I've never seen this happen but, according to the TypeScript type definitions
-  // provided by AWS, `Lambda.InvocationResponse.Payload` could be `undefined`.
+  // provided by AWS, `InvocationResponse.Payload` could be `undefined`.
   if (invocationResponse.Payload === undefined) {
     logger.error('Undefined Payload returned from pre-hook lambda')
     return internalServerError
@@ -111,26 +111,26 @@ const invokePreHook = async (lambda, preHook, payload) => {
 }
 
 /**
- * @param {any} lambda
+ * @param {Lambda} lambda
  * @param {string} postHook
  * @param {APIGatewayProxyResult} payload
  * @returns {Promise<APIGatewayProxyResult>}
  */
 const invokePostHook = async (lambda, postHook, payload) => {
-  /** @type {Lambda.InvocationResponse} */
+  /** @type {import("@aws-sdk/client-lambda").InvocationResponse} */
   let invocationResponse
   try {
     invocationResponse = await lambda.invoke({
       FunctionName: postHook,
       Payload: JSON.stringify(payload)
-    }).promise()
+    })
   } catch (error) {
     logger.error('Failed to invoke post-hook lambda:', error)
     return internalServerError
   }
 
   // I've never seen this happen but, according to the TypeScript type definitions
-  // provided by AWS, `Lambda.InvocationResponse.Payload` could be `undefined`.
+  // provided by AWS, `InvocationResponse.Payload` could be `undefined`.
   if (invocationResponse.Payload === undefined) {
     logger.error('Undefined Payload returned from post-hook lambda')
     return internalServerError

--- a/src/lambdas/api/index.js
+++ b/src/lambdas/api/index.js
@@ -64,7 +64,7 @@ const logZodParseError = (data, error) => {
 }
 
 /**
- * @param {Lambda} lambda
+ * @param {any} lambda
  * @param {string} preHook
  * @param {APIGatewayProxyEvent} payload
  * @returns {Promise<APIGatewayProxyEvent|APIGatewayProxyResult>}
@@ -111,7 +111,7 @@ const invokePreHook = async (lambda, preHook, payload) => {
 }
 
 /**
- * @param {Lambda} lambda
+ * @param {any} lambda
  * @param {string} postHook
  * @param {APIGatewayProxyResult} payload
  * @returns {Promise<APIGatewayProxyResult>}

--- a/src/lambdas/api/webpack.config.js
+++ b/src/lambdas/api/webpack.config.js
@@ -20,9 +20,6 @@ export default {
     filename: 'index.js',
     path: resolve(__dirname, '..', '..', '..', 'dist', 'api')
   },
-  externals: [
-    'aws-sdk'
-  ],
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],

--- a/src/lambdas/ingest/webpack.config.js
+++ b/src/lambdas/ingest/webpack.config.js
@@ -19,9 +19,6 @@ export default {
     filename: 'index.js',
     path: resolve(__dirname, '..', '..', '..', 'dist', 'ingest')
   },
-  externals: [
-    'aws-sdk'
-  ],
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],

--- a/src/lambdas/post-hook/webpack.config.js
+++ b/src/lambdas/post-hook/webpack.config.js
@@ -19,9 +19,6 @@ export default {
     filename: 'index.js',
     path: resolve(__dirname, '..', '..', '..', 'dist', 'post-hook')
   },
-  externals: [
-    'aws-sdk'
-  ],
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],

--- a/src/lambdas/pre-hook/webpack.config.js
+++ b/src/lambdas/pre-hook/webpack.config.js
@@ -19,9 +19,6 @@ export default {
     filename: 'index.js',
     path: resolve(__dirname, '..', '..', '..', 'dist', 'pre-hook')
   },
-  externals: [
-    'aws-sdk'
-  ],
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],

--- a/src/lib/database-client.js
+++ b/src/lib/database-client.js
@@ -86,7 +86,10 @@ export async function createIndex(index) {
       logger.info(`Created index ${index}`)
       logger.debug('Mapping: %j', indexConfiguration)
     } catch (error) {
-      logger.debug(`Error creating index '${index}'`, error)
+      logger.error(`Error creating index '${index}'`, error)
+      throw error
     }
+  } else {
+    logger.error(`${index} already exists.`)
   }
 }

--- a/tests/unit/test-ingest-1.js
+++ b/tests/unit/test-ingest-1.js
@@ -12,11 +12,7 @@ const setup = () => {
     promise: () => (Promise.resolve(true))
   })
   ECS.prototype.runTask = runTask
-  const AWS = {
-    ECS
-  }
   const lambda = proxyquire('../../src/lambdas/ingest/', {
-    'aws-sdk': AWS
   })
   return {
     ingest,


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. Removes usage of aws-sdk, which just happened to work locally because of a transient dev dependency, but failed when deployed as a lambda
2. Updates localstack to use version 3, since apparently version 2 no longer works with the sdk changes or something?

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
