### PR TITLE
ingest failures will propagate to a lambda failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+
+### Changed
+
+- Ingest lambda will return a failure if there are errors during ingesting. Previously,
+  errors would only be logged and the lambda would always return a success response.
+
 ## [3.3.0] - 2023-12-04
 
 ### Added
@@ -412,7 +419,7 @@ Initial release, forked from [sat-api](https://github.com/sat-utils/sat-api/tree
 
 Compliant with STAC 0.9.0
 
-<!-- [Unreleased]: https://github.com/stac-utils/stac-api/compare/v2.4.0...main -->
+[Unreleased]: https://github.com/stac-utils/stac-api/compare/v3.3.0...main
 [3.3.0]: https://github.com/stac-utils/stac-api/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/stac-utils/stac-api/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/stac-utils/stac-api/compare/v3.0.0...v3.1.0

--- a/src/lib/ingest.js
+++ b/src/lib/ingest.js
@@ -132,7 +132,7 @@ function logIngestItemsResults(results) {
       if (result.error instanceof InvalidIngestError) {
         // Attempting to ingest invalid stac objects is not a system error so we
         // log it as info and not error
-        logger.info('Invalid ingest item', result.error)
+        logger.warn('Invalid ingest item', result.error)
       } else {
         logger.error('Error while ingesting item', result.error)
       }

--- a/tests/helpers/ingest.js
+++ b/tests/helpers/ingest.js
@@ -74,7 +74,7 @@ export const ingestFixtureC = (ingestTopicArn, ingestQueueUrl) =>
     overrides
   })
 
-export async function testPostIngestSNS(t, record) {
+export async function testPostIngestSNS(t, record, shouldError = false) {
   // @ts-ignore
   process.env.POST_INGEST_TOPIC_ARN = t.context.postIngestTopicArn
 
@@ -83,7 +83,13 @@ export async function testPostIngestSNS(t, record) {
     Message: JSON.stringify(record)
   })
 
-  await sqsTriggerLambda(t.context.ingestQueueUrl, handler)
+  try {
+    await sqsTriggerLambda(t.context.ingestQueueUrl, handler)
+  } catch (e) {
+    if (!shouldError) {
+      t.fail('Ingest had error, but should not have.')
+    }
+  }
 
   const { Messages } = await sqs().receiveMessage({
     QueueUrl: t.context.postIngestQueueUrl,

--- a/tests/system/test-ingest.js
+++ b/tests/system/test-ingest.js
@@ -392,7 +392,7 @@ test('Ingest collection failure is published to post-ingest SNS topic', async (t
   const { message, attrs } = await testPostIngestSNS(t, {
     type: 'Collection',
     id: 'badCollection'
-  })
+  }, true)
 
   t.is(message.record.id, 'badCollection')
   t.is(attrs.collection.Value, 'badCollection')
@@ -482,7 +482,7 @@ test('Ingest item failure is published to post-ingest SNS topic', async (t) => {
     type: 'Feature',
     id: 'badItem',
     collection: collection.id
-  })
+  }, true)
 
   t.is(message.record.id, 'badItem')
   t.is(attrs.collection.Value, collection.id)
@@ -514,7 +514,7 @@ test('Ingested item is published to post-ingest SNS topic with updated links', a
   }
 })
 
-test('Ingested item facilure is published to post-ingest SNS topic without updated links', async (t) => {
+test('Ingested item failure is published to post-ingest SNS topic without updated links', async (t) => {
   const envBeforeTest = { ...process.env }
   try {
     const hostname = 'some-stac-server.com'
@@ -526,7 +526,7 @@ test('Ingested item facilure is published to post-ingest SNS topic without updat
       { id: randomId('item'), collection: 'INVALID COLLECTION' }
     )
 
-    const { message } = await testPostIngestSNS(t, item)
+    const { message } = await testPostIngestSNS(t, item, true)
 
     t.truthy(message.record.links)
     t.false(message.record.links.every((/** @type {Link} */ link) => (


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/660


**Proposed Changes:**

1.  Currently, if any item fails to ingest, a message is logged, but the lambda always returns success. This changes that, so if any item fails to ingest, the lambda will fail too.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
