### PR TITLE
fix bug where next param was missing when sortby was specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2024-01-19
+
+### Fixed
+
+- When using sortby, next links were incorrect.
+
 ## [3.4.0] - 2023-12-15
 
 ### Changed
@@ -422,6 +428,7 @@ Initial release, forked from [sat-api](https://github.com/sat-utils/sat-api/tree
 Compliant with STAC 0.9.0
 
 <!-- [Unreleased]: https://github.com/stac-utils/stac-api/compare/v3.3.0...main -->
+[3.5.0]: https://github.com/stac-utils/stac-api/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/stac-utils/stac-api/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/stac-utils/stac-api/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/stac-utils/stac-api/compare/v3.1.0...v3.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stac-server",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stac-server",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.474.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "stac-server",
   "description": "A STAC API running on stac-server",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "repository": "https://github.com/stac-utils/stac-server",
   "author": "Alireza Jazayeri, Matthew Hanson, Sean Harkins, Phil Varner",
   "license": "MIT",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -549,27 +549,29 @@ const buildPaginationLinks = function (limit, parameters, bbox, intersects, endp
 
     const lastItem = items[items.length - 1]
 
-    const nextKeys = sortby ? Object.keys(sortby) : ['properties.datetime', 'id', 'collection']
+    const nextKeys = sortby ? sortby.map((x) => x.field)
+      : ['properties.datetime', 'id', 'collection']
 
     const next = nextKeys.map((k) => getNested(lastItem, k)).join(',')
 
-    const nextParams = pickBy(assign(parameters, { bbox, intersects, limit, next }))
-
-    const link = {
-      rel: 'next',
-      title: 'Next page of Items',
-      method: httpMethod,
-      type: 'application/geo+json'
+    if (next) {
+      const link = {
+        rel: 'next',
+        title: 'Next page of Items',
+        method: httpMethod,
+        type: 'application/geo+json'
+      }
+      const nextParams = pickBy(assign(parameters, { bbox, intersects, limit, next }))
+      if (httpMethod === 'GET') {
+        const nextQueryParameters = dictToURI(nextParams)
+        link.href = `${endpoint}?${nextQueryParameters}`
+      } else if (httpMethod === 'POST') {
+        link.href = endpoint
+        link.merge = false
+        link.body = nextParams
+      }
+      return [link]
     }
-    if (httpMethod === 'GET') {
-      const nextQueryParameters = dictToURI(nextParams)
-      link.href = `${endpoint}?${nextQueryParameters}`
-    } else if (httpMethod === 'POST') {
-      link.href = endpoint
-      link.merge = false
-      link.body = nextParams
-    }
-    return [link]
   }
   return []
 }


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/589


**Proposed Changes:**

1. when sortby is used, correctly return a next parameter in the next link
2. release prep for 3.5.0


**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
