### PR TITLE
update to opensearch 2.13 by default

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: package.json
       - uses: ankane/setup-opensearch@v1
         with:
-          opensearch-version: 2.11
+          opensearch-version: 2.13
       - name: Upgrade npm
         run: npm install -g npm@8.19.4
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.8.0] - 2024-05-29
+
+### Changed
+
+- Update to default to OpenSearch 2.13
+
 ## [3.7.0] - 2024-05-14
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.11.0
+    image: opensearchproject/opensearch:2.13.0
     ports:
       - "127.0.0.1:9200:9200"
       - "127.0.0.1:9300:9300"

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -184,7 +184,7 @@ resources:
           InstanceCount: 1
           DedicatedMasterEnabled: false
           ZoneAwarenessEnabled: false
-        EngineVersion: OpenSearch_2.11
+        EngineVersion: OpenSearch_2.13
         DomainEndpointOptions:
           EnforceHTTPS: true
         NodeToNodeEncryptionOptions:


### PR DESCRIPTION
**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. update opensearch to 2.13 by default

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
