### PR TITLE
Add filter extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Minimum implementation (basic-cql2 conformance class) of the filter extension for the
+  `search` and `aggregate` endpoints. Only CQL2 JSON is supported.
+
 ## [3.8.0] - 2024-05-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Minimum implementation (basic-cql2 conformance class) of the filter extension for the
-  `search` and `aggregate` endpoints. Only CQL2 JSON is supported.
+  `/search` (GET and POST), `/collections/{collectionId}/items` (GET), and `/aggregate`
+  (GET) endpoints. Only CQL2 JSON is supported.
 
 ## [3.8.0] - 2024-05-29
 
@@ -472,6 +473,7 @@ Initial release, forked from [sat-api](https://github.com/sat-utils/sat-api/tree
 Compliant with STAC 0.9.0
 
 <!-- [unreleased]: https://github.com/stac-utils/stac-api/compare/v3.6.0...main -->
+
 [3.7.0]: https://github.com/stac-utils/stac-api/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/stac-utils/stac-api/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/stac-utils/stac-api/compare/v3.4.0...v3.5.0

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Currently, stac-server supports the following specifications:
 - STAC API - Features
 - STAC API - Collections
 - STAC API - Item Search
-- Context Extension
+- Context Extension (deprecated)
 - Sort Extension
 - Fields Extension
 - Query Extension

--- a/README.md
+++ b/README.md
@@ -945,9 +945,9 @@ not advertise any queryables properties (note the empty `properties` field):
 ### Filter Extension
 
 Stac-server currently implements the Filter Extension such that the `id`, `collection`,
-`geometry`, and `bbox` Item fields and all fields in the `properties` object of an Item
-are always available as filter terms for a Collection, regardless of whether a Collection
-defines a `queryables` field or not. This behavior aligns with a value of `true` for the
+and `geometry` Item fields and all fields in the `properties` object of an Item are always
+available as filter terms for a Collection, regardless of whether a Collection defines a
+`queryables` field or not. This behavior aligns with a value of `true` for the
 `additionalProperties` field in the queryables definition. Stac-server currently
 _requires_ `additionalProperties` to be `true`; a value of `false`, which would restrict
 filtering to only those `properties` defined in a Collection's queryable schema, is not
@@ -956,7 +956,11 @@ informative only - it does not change the behavior of a filter.
 
 Note that when creating a filter expression that uses fields from the `properties` object
 in an Item, the fields **must not** be prefixed, e.g., use `eo:cloud_cover` instead of
-`properties.eo:cloud_cover` in the filter expression.
+`properties.eo:cloud_cover` in the filter expression. Care must be taken that terms used
+in a filter expression exactly match the field names in the Item `properties` object.
+There is no validation that filter expression terms are correct, so if you search for a
+field that doesn't exist in an Item's `properties` object, that Item will never be
+matched.
 
 ### Query Extension
 

--- a/README.md
+++ b/README.md
@@ -945,22 +945,31 @@ not advertise any queryables properties (note the empty `properties` field):
 ### Filter Extension
 
 Stac-server currently implements the Filter Extension such that the `id`, `collection`,
-and `geometry` Item fields and all fields in the `properties` object of an Item are always
-available as filter terms for a Collection, regardless of whether a Collection defines a
-`queryables` field or not. This behavior aligns with a value of `true` for the
+`bbox`, and `geometry` Item fields and all fields in the `properties` object of an Item
+are always available as filter terms for a Collection, regardless of whether a Collection
+defines a `queryables` field or not. This behavior aligns with a value of `true` for the
 `additionalProperties` field in the queryables definition. Stac-server currently
-_requires_ `additionalProperties` to be `true`; a value of `false`, which would restrict
-filtering to only those `properties` defined in a Collection's queryable schema, is not
+**requires** `additionalProperties` to be `true`; a value of `false`, which would restrict
+filtering to only those `properties` defined in a Collection's queryables schema, is not
 supported and will raise an error. Thus, adding a `queryables` field to a Collection is
 informative only - it does not change the behavior of a filter.
 
 Note that when creating a filter expression that uses fields from the `properties` object
 in an Item, the fields **must not** be prefixed, e.g., use `eo:cloud_cover` instead of
 `properties.eo:cloud_cover` in the filter expression. Care must be taken that terms used
-in a filter expression exactly match the field names in the Item `properties` object.
-There is no validation that filter expression terms are correct, so if you search for a
+in a filter expression exactly match the field names in the Item `properties` object;
+there is no validation that filter expression terms are correct, so if you search for a
 field that doesn't exist in an Item's `properties` object, that Item will never be
 matched.
+
+The`id`, `collection`, `bbox`, and `geometry` fields also **must not** be prefixed since
+they are top-level Item fields. Note that until the [Basic Spatial Functions with
+additional Spatial
+Literals](https://docs.ogc.org/is/21-065r2/21-065r2.html#rc_basic-spatial-functions-plus)
+and [Array
+Functions](https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_class_array_functions)
+conformance classes are implemented, searching over the `bbox` and `geometry` fields is
+not supported.
 
 ### Query Extension
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ Currently, stac-server supports the following specifications:
 - STAC API - Features
 - STAC API - Collections
 - STAC API - Item Search
+- Context Extension
+- Sort Extension
+- Fields Extension
 - Query Extension
 - Filter Extension
-- Fields Extension
-- Sort Extension
+- Transaction Extension
 - Aggregation Extension (experimental)
 
 The following APIs are deployed instances of stac-server:

--- a/README.md
+++ b/README.md
@@ -955,8 +955,8 @@ supported and will raise an error. Thus, adding a `queryables` field to a Collec
 informative only - it does not change the behavior of a filter.
 
 Note that when creating a filter expression that uses fields from the `properties` object
-in an Item, the fields should not be prefixed, e.g., use `eo:cloud_cover`, not
-`properties.eo:cloud_cover`, in the filter expression.
+in an Item, the fields **must not** be prefixed, e.g., use `eo:cloud_cover` instead of
+`properties.eo:cloud_cover` in the filter expression.
 
 ### Query Extension
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,261 +561,619 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.575.0.tgz",
-      "integrity": "sha512-T9VxagVucalLJLlj0XNMkgl0Cq/Va5uRqZTIfsTMVRj5VRlx2vZHVblSc/T6P4tWEsah6EB2RjM3Tm+ZyOPBjA==",
+      "version": "3.726.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.726.1.tgz",
+      "integrity": "sha512-jubn85XtrKZdhQonSGr+qvWHO0dAa4gGqQKG7O6u7NJP666dGDhj5cowTbXyapy4F8sV6/9B/gUrdby8pw9ECQ==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sso-oidc": "3.575.0",
-        "@aws-sdk/client-sts": "3.575.0",
-        "@aws-sdk/core": "3.575.0",
-        "@aws-sdk/credential-provider-node": "3.575.0",
-        "@aws-sdk/middleware-host-header": "3.575.0",
-        "@aws-sdk/middleware-logger": "3.575.0",
-        "@aws-sdk/middleware-recursion-detection": "3.575.0",
-        "@aws-sdk/middleware-user-agent": "3.575.0",
-        "@aws-sdk/region-config-resolver": "3.575.0",
-        "@aws-sdk/types": "3.575.0",
-        "@aws-sdk/util-endpoints": "3.575.0",
-        "@aws-sdk/util-user-agent-browser": "3.575.0",
-        "@aws-sdk/util-user-agent-node": "3.575.0",
-        "@smithy/config-resolver": "^3.0.0",
-        "@smithy/core": "^2.0.0",
-        "@smithy/eventstream-serde-browser": "^3.0.0",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.0",
-        "@smithy/eventstream-serde-node": "^3.0.0",
-        "@smithy/fetch-http-handler": "^3.0.0",
-        "@smithy/hash-node": "^3.0.0",
-        "@smithy/invalid-dependency": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.0",
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-retry": "^3.0.0",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.0",
-        "@smithy/util-defaults-mode-node": "^3.0.0",
-        "@smithy/util-endpoints": "^2.0.0",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
-        "@smithy/util-stream": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.0.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.726.0",
+        "@aws-sdk/client-sts": "3.726.1",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/credential-provider-node": "3.726.0",
+        "@aws-sdk/middleware-host-header": "3.723.0",
+        "@aws-sdk/middleware-logger": "3.723.0",
+        "@aws-sdk/middleware-recursion-detection": "3.723.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/region-config-resolver": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@aws-sdk/util-user-agent-browser": "3.723.0",
+        "@aws-sdk/util-user-agent-node": "3.726.0",
+        "@smithy/config-resolver": "^4.0.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/eventstream-serde-browser": "^4.0.0",
+        "@smithy/eventstream-serde-config-resolver": "^4.0.0",
+        "@smithy/eventstream-serde-node": "^4.0.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/hash-node": "^4.0.0",
+        "@smithy/invalid-dependency": "^4.0.0",
+        "@smithy/middleware-content-length": "^4.0.0",
+        "@smithy/middleware-endpoint": "^4.0.0",
+        "@smithy/middleware-retry": "^4.0.0",
+        "@smithy/middleware-serde": "^4.0.0",
+        "@smithy/middleware-stack": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/url-parser": "^4.0.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.0",
+        "@smithy/util-defaults-mode-node": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/util-retry": "^4.0.0",
+        "@smithy/util-stream": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.726.0.tgz",
+      "integrity": "sha512-NM5pjv2qglEc4XN3nnDqtqGsSGv1k5YTmzDo3W3pObItHmpS8grSeNfX9zSH+aVl0Q8hE4ZIgvTPNZ+GzwVlqg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/middleware-host-header": "3.723.0",
+        "@aws-sdk/middleware-logger": "3.723.0",
+        "@aws-sdk/middleware-recursion-detection": "3.723.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/region-config-resolver": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@aws-sdk/util-user-agent-browser": "3.723.0",
+        "@aws-sdk/util-user-agent-node": "3.726.0",
+        "@smithy/config-resolver": "^4.0.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/hash-node": "^4.0.0",
+        "@smithy/invalid-dependency": "^4.0.0",
+        "@smithy/middleware-content-length": "^4.0.0",
+        "@smithy/middleware-endpoint": "^4.0.0",
+        "@smithy/middleware-retry": "^4.0.0",
+        "@smithy/middleware-serde": "^4.0.0",
+        "@smithy/middleware-stack": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/url-parser": "^4.0.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.0",
+        "@smithy/util-defaults-mode-node": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/util-retry": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.726.0.tgz",
+      "integrity": "sha512-5JzTX9jwev7+y2Jkzjz0pd1wobB5JQfPOQF3N2DrJ5Pao0/k6uRYwE4NqB0p0HlGrMTDm7xNq7OSPPIPG575Jw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/credential-provider-node": "3.726.0",
+        "@aws-sdk/middleware-host-header": "3.723.0",
+        "@aws-sdk/middleware-logger": "3.723.0",
+        "@aws-sdk/middleware-recursion-detection": "3.723.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/region-config-resolver": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@aws-sdk/util-user-agent-browser": "3.723.0",
+        "@aws-sdk/util-user-agent-node": "3.726.0",
+        "@smithy/config-resolver": "^4.0.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/hash-node": "^4.0.0",
+        "@smithy/invalid-dependency": "^4.0.0",
+        "@smithy/middleware-content-length": "^4.0.0",
+        "@smithy/middleware-endpoint": "^4.0.0",
+        "@smithy/middleware-retry": "^4.0.0",
+        "@smithy/middleware-serde": "^4.0.0",
+        "@smithy/middleware-stack": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/url-parser": "^4.0.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.0",
+        "@smithy/util-defaults-mode-node": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/util-retry": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.726.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sts": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.575.0.tgz",
-      "integrity": "sha512-8MrT4J2dRiskf0JFMGL5VNBqPvc6igNa218LGBJzHXmLsm1WfGCGnce84R7U2USr8oPOenu0XzSCLvMQyZbGWQ==",
+      "version": "3.726.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.726.1.tgz",
+      "integrity": "sha512-qh9Q9Vu1hrM/wMBOBIaskwnE4GTFaZu26Q6WHwyWNfj7J8a40vBxpW16c2vYXHLBtwRKM1be8uRLkmDwghpiNw==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sso-oidc": "3.575.0",
-        "@aws-sdk/core": "3.575.0",
-        "@aws-sdk/credential-provider-node": "3.575.0",
-        "@aws-sdk/middleware-host-header": "3.575.0",
-        "@aws-sdk/middleware-logger": "3.575.0",
-        "@aws-sdk/middleware-recursion-detection": "3.575.0",
-        "@aws-sdk/middleware-user-agent": "3.575.0",
-        "@aws-sdk/region-config-resolver": "3.575.0",
-        "@aws-sdk/types": "3.575.0",
-        "@aws-sdk/util-endpoints": "3.575.0",
-        "@aws-sdk/util-user-agent-browser": "3.575.0",
-        "@aws-sdk/util-user-agent-node": "3.575.0",
-        "@smithy/config-resolver": "^3.0.0",
-        "@smithy/core": "^2.0.0",
-        "@smithy/fetch-http-handler": "^3.0.0",
-        "@smithy/hash-node": "^3.0.0",
-        "@smithy/invalid-dependency": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.0",
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-retry": "^3.0.0",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.0",
-        "@smithy/util-defaults-mode-node": "^3.0.0",
-        "@smithy/util-endpoints": "^2.0.0",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.726.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/credential-provider-node": "3.726.0",
+        "@aws-sdk/middleware-host-header": "3.723.0",
+        "@aws-sdk/middleware-logger": "3.723.0",
+        "@aws-sdk/middleware-recursion-detection": "3.723.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/region-config-resolver": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@aws-sdk/util-user-agent-browser": "3.723.0",
+        "@aws-sdk/util-user-agent-node": "3.726.0",
+        "@smithy/config-resolver": "^4.0.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/hash-node": "^4.0.0",
+        "@smithy/invalid-dependency": "^4.0.0",
+        "@smithy/middleware-content-length": "^4.0.0",
+        "@smithy/middleware-endpoint": "^4.0.0",
+        "@smithy/middleware-retry": "^4.0.0",
+        "@smithy/middleware-serde": "^4.0.0",
+        "@smithy/middleware-stack": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/url-parser": "^4.0.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.0",
+        "@smithy/util-defaults-mode-node": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/util-retry": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/core": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.575.0.tgz",
-      "integrity": "sha512-117U+kQki2XoKcYQfepmlRcNxn6rELGlOFOBQ8Z2JTBXEYHblW2ke067a0CLmxFwp/zCWuc7IGjd3in3x4Q3rg==",
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
+      "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
       "dev": true,
       "dependencies": {
-        "@smithy/core": "^2.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/signature-v4": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "fast-xml-parser": "4.2.5",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/signature-v4": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.723.0.tgz",
+      "integrity": "sha512-OuH2yULYUHTVDUotBoP/9AEUIJPn81GQ/YBtZLoo2QyezRJ2QiO/1epVtbJlhNZRwXrToLEDmQGA2QfC8c7pbA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.723.0.tgz",
+      "integrity": "sha512-DTsKC6xo/kz/ZSs1IcdbQMTgiYbpGTGEd83kngFc1bzmw7AmK92DBZKNZpumf8R/UfSpTcj9zzUUmrWz1kD0eQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/util-stream": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.726.0.tgz",
+      "integrity": "sha512-seTtcKL2+gZX6yK1QRPr5mDJIBOatrpoyrO8D5b8plYtV/PDbDW3mtDJSWFHet29G61ZmlNElyXRqQCXn9WX+A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/credential-provider-env": "3.723.0",
+        "@aws-sdk/credential-provider-http": "3.723.0",
+        "@aws-sdk/credential-provider-process": "3.723.0",
+        "@aws-sdk/credential-provider-sso": "3.726.0",
+        "@aws-sdk/credential-provider-web-identity": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/credential-provider-imds": "^4.0.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.726.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.726.0.tgz",
+      "integrity": "sha512-jjsewBcw/uLi24x8JbnuDjJad4VA9ROCE94uVRbEnGmUEsds75FWOKp3fWZLQlmjLtzsIbJOZLALkZP86liPaw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.723.0",
+        "@aws-sdk/credential-provider-http": "3.723.0",
+        "@aws-sdk/credential-provider-ini": "3.726.0",
+        "@aws-sdk/credential-provider-process": "3.723.0",
+        "@aws-sdk/credential-provider-sso": "3.726.0",
+        "@aws-sdk/credential-provider-web-identity": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/credential-provider-imds": "^4.0.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.723.0.tgz",
+      "integrity": "sha512-fgupvUjz1+jeoCBA7GMv0L6xEk92IN6VdF4YcFhsgRHlHvNgm7ayaoKQg7pz2JAAhG/3jPX6fp0ASNy+xOhmPA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.726.0.tgz",
+      "integrity": "sha512-WxkN76WeB08j2yw7jUH9yCMPxmT9eBFd9ZA/aACG7yzOIlsz7gvG3P2FQ0tVg25GHM0E4PdU3p/ByTOawzcOAg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.726.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/token-providers": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.723.0.tgz",
+      "integrity": "sha512-tl7pojbFbr3qLcOE6xWaNCf1zEfZrIdSJtOPeSXfV/thFMMAvIjgf3YN6Zo1a6cxGee8zrV/C8PgOH33n+Ev/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.723.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.575.0.tgz",
-      "integrity": "sha512-V2WoLBiXNCc4rIWZt6FUcP4TN0Vk02A9PPCBWkTfyOooiqfq+WZmZjRRBpwl1+5UsvARslrKWF0VzheMRXPJLQ==",
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
+      "integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.575.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/types": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.575.0.tgz",
-      "integrity": "sha512-7DEKx9Z11Maaye7FfhYtC8rjbM/PcFcMO2N4QEAfypcgWCj+w4gseE2OGdfAH9OFDoFc6YvLp53v16vbPjzQSg==",
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
+      "integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.575.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/types": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.575.0.tgz",
-      "integrity": "sha512-ri89ldRFos6KZDGaknWPS2XPO9qr+gZ7+mPaoU8YkSM1W4uKqtnUSONyc+O3CFGJrqReuGHhRq0l2Sld0bjwOw==",
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
+      "integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.575.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/types": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.575.0.tgz",
-      "integrity": "sha512-fWlr4RfrUNS2R3PgP+WsoMYORAgv/47Lp0J0fb3dXO1YvdczNWddRbFSUX2MQxM/y9XFfQPLpLgzluhoL3Cjeg==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.726.0.tgz",
+      "integrity": "sha512-hZvzuE5S0JmFie1r68K2wQvJbzyxJFdzltj9skgnnwdvLe8F/tz7MqLkm28uV0m4jeHk0LpiBo6eZaPkQiwsZQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.575.0",
-        "@aws-sdk/util-endpoints": "3.575.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/types": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.575.0.tgz",
-      "integrity": "sha512-sBJKwTWKCWu9y8FzXIijYGwkKr3tDkPXM7BylToe6W+tGkp4OirV4iXrWA9zReNwTTepoxHufofqjGK9BtcI8g==",
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
+      "integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.575.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.723.0.tgz",
+      "integrity": "sha512-hniWi1x4JHVwKElANh9afKIMUhAutHVBRD8zo6usr0PAoj+Waf220+1ULS74GXtLXAPCiNXl5Og+PHA7xT8ElQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.723.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.575.0.tgz",
-      "integrity": "sha512-XrnolQGs0wXxdgNudirR14OgNOarH7WUif38+2Pd4onZH+L7XoILem0EgA1tRpgFpw2pFHlZCNaAHDNSBEal7g==",
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
+      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.575.0.tgz",
-      "integrity": "sha512-wC5x+V6w3kRlR6X6XVINsAPDYG+Tzs3Wthlw+YLtjuPODUNZIQAqsABHahxnekFyAvse+1929Hwo+CaL+BHZGA==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.726.0.tgz",
+      "integrity": "sha512-sLd30ASsPMoPn3XBK50oe/bkpJ4N8Bpb7SbhoxcY3Lk+fSASaWxbbXE81nbvCnkxrZCvkPOiDHzJCp1E2im71A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.575.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-endpoints": "^2.0.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.575.0.tgz",
-      "integrity": "sha512-iADonXyaXgwvC4T0qRuDWCdKInz82GX2cyezq/oqVlL8bPY7HD8jwZZruuJdq5tkaJi1EhbO4+f1ksZqOiZKvQ==",
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
+      "integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.575.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/types": "^4.0.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.575.0.tgz",
-      "integrity": "sha512-kwzvBfA0LoILDOFS6BV8uOkksBHrYulP6kNXegB5eZnDSNia5DbBsXqxQ/HknNF5a429SWQw2aaQJEgQvZB1VA==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.726.0.tgz",
+      "integrity": "sha512-iEj6KX9o6IQf23oziorveRqyzyclWai95oZHDJtYav3fvLJKStwSjygO4xSF7ycHcTYeCHSLO1FFOHgGVs4Viw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.575.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/types": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -827,548 +1185,713 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/config-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
-      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+      "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-swFv0wQiK7TGHeuAp6lfF5Kw1dHWsTrCuc+yh4Kh05gEShjsE2RUxHucEerR9ih9JITNtaHcSpUThn5Y/vDw0A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-stream": "^4.0.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/credential-provider-imds": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
-      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+      "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/url-parser": "^4.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/eventstream-codec": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.1.tgz",
+      "integrity": "sha512-Q2bCAAR6zXNVtJgifsU16ZjKGqdw/DyecKNgIgi7dlqw04fqDu0mnq+JmGphqheypVc64CYq3azSuCpAdFk2+A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.1.tgz",
+      "integrity": "sha512-HbIybmz5rhNg+zxKiyVAnvdM3vkzjE6ccrJ620iPL8IXcJEntd3hnBl+ktMwIy12Te/kyrSbUb8UCdnUT4QEdA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.0.1.tgz",
+      "integrity": "sha512-lSipaiq3rmHguHa3QFF4YcCM3VJOrY9oq2sow3qlhFY+nBSTF/nrO82MUQRPrxHQXA58J5G1UnU2WuJfi465BA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
+      "integrity": "sha512-o4CoOI6oYGYJ4zXo34U8X9szDe3oGjmHgsMGiZM0j4vtNoT+h80TLnkUcrLZR3+E6HIxqW+G+9WHAVfl0GXK0Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.1.tgz",
+      "integrity": "sha512-Z94uZp0tGJuxds3iEAZBqGU2QiaBHP4YytLUjwZWx+oUeohCsLyUm33yp4MMBmhkuPqSbQCXq5hDet6JGUgHWA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/fetch-http-handler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.0.tgz",
-      "integrity": "sha512-gP1MlOpIB/onIbh4g9eSG3XdI/G31cAvd9Lo11192eL4mxks3xpkPaa+RIcZaX2Vmb8I8HzxBddPSXviY1iq0w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+      "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
       "dev": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-base64": "^3.0.0",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/querystring-builder": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/hash-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
-      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+      "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
-      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+      "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
-      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+      "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
-      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.1.tgz",
+      "integrity": "sha512-hCCOPu9+sRI7Wj0rZKKnGylKXBEd9cQJetzjQqe8cT4PWvtQAbvNVa6cgAONiZg9m8LaXtP9/waxm3C3eO4hiw==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/shared-ini-file-loader": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/core": "^3.1.0",
+        "@smithy/middleware-serde": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/shared-ini-file-loader": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/url-parser": "^4.0.1",
+        "@smithy/util-middleware": "^4.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/middleware-retry": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.0.tgz",
-      "integrity": "sha512-kFaBiTa50y0iwhrOjX5UISo1SfiXPrE1EsMtZJAVF7Oci3AUpVzaMzRxzQJFGnxioSyCwSmzqiE9x4X3dW+7VQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.1.tgz",
+      "integrity": "sha512-n3g2zZFgOWaz2ZYCy8+4wxSmq+HSTD8QKkRhFDv+nkxY1o7gzyp4PDz/+tOdcNPMPZ/A6Mt4aVECYNjQNiaHJw==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/service-error-classification": "^4.0.1",
+        "@smithy/smithy-client": "^4.1.0",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-retry": "^4.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/middleware-serde": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
-      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.1.tgz",
+      "integrity": "sha512-Fh0E2SOF+S+P1+CsgKyiBInAt3o2b6Qk7YOp2W0Qx2XnfTdfMuSDKUEcnrtpxCzgKJnqXeLUZYqtThaP0VGqtA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/middleware-stack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
-      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+      "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/node-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
-      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+      "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/shared-ini-file-loader": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/shared-ini-file-loader": "^4.0.1",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/node-http-handler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
-      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.1.tgz",
+      "integrity": "sha512-ddQc7tvXiVLC5c3QKraGWde761KSk+mboCheZoWtuqnXh5l0WKyFy3NfDIM/dsKrI9HlLVH/21pi9wWK2gUFFA==",
       "dev": true,
       "dependencies": {
-        "@smithy/abort-controller": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/abort-controller": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/querystring-builder": "^4.0.1",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/property-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
-      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+      "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/protocol-http": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
-      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+      "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/querystring-builder": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
-      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+      "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/querystring-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
-      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+      "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
-      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+      "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0"
+        "@smithy/types": "^4.1.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
-      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+      "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/signature-v4": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
-      "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+      "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
       "dev": true,
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/smithy-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.0.tgz",
-      "integrity": "sha512-HTLlEOPOoPxyVCoqzwRGJuRh4hyAAo+eveRcEPi7UpIaq2PCAmdFZM76jabUuzlPPR9ge+OQlKzZre+LT1nXzA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.0.tgz",
+      "integrity": "sha512-NiboZnrsrZY+Cy5hQNbYi+nVNssXVi2I+yL4CIKNIanOhH8kpC5PKQ2jx/MQpwVr21a3XcVoQBArlpRF36OeEQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-stream": "^3.0.0",
+        "@smithy/core": "^3.1.0",
+        "@smithy/middleware-endpoint": "^4.0.1",
+        "@smithy/middleware-stack": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-stream": "^4.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/url-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
-      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+      "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
       "dev": true,
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/querystring-parser": "^4.0.1",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-base64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
       "dev": true,
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-body-length-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-body-length-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
-      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.0.tgz",
-      "integrity": "sha512-/ChTQXFZVK/92dLR9RLW2fOG03ghgUYZnRfrs9d9T3L7UxtsGx9QitF7Ppu64A8xcUHqA30kV7TUayFRBd7YQw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.1.tgz",
+      "integrity": "sha512-nkQifWzWUHw/D0aLPgyKut+QnJ5X+5E8wBvGfvrYLLZ86xPfVO6MoqfQo/9s4bF3Xscefua1M6KLZtobHMWrBg==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/smithy-client": "^4.1.0",
+        "@smithy/types": "^4.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.0.tgz",
-      "integrity": "sha512-gfABCXswcMgDUcVO+16e4BgTFnouaXNCowp9mVxV8dgaOCpUT9eEWIC+PK3ZoEm26QwlwT7WgfuN1Y22HKX36g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.1.tgz",
+      "integrity": "sha512-LeAx2faB83litC9vaOdwFaldtto2gczUHxfFf8yoRwDU3cwL4/pDm7i0hxsuBCRk5mzHsrVGw+3EVCj32UZMdw==",
       "dev": true,
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.0",
-        "@smithy/credential-provider-imds": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/config-resolver": "^4.0.1",
+        "@smithy/credential-provider-imds": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/smithy-client": "^4.1.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-endpoints": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
-      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+      "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-hex-encoding": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-middleware": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
-      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+      "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-retry": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
-      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+      "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
       "dev": true,
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/service-error-classification": "^4.0.1",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.0.tgz",
-      "integrity": "sha512-AYQeeAxBi3yee9SXC0HgrbeIchQeo6EAkpiwwmmCK6Z7uq8GnMGe8AxRZT3O4wyMNRNK2qfjZSvx6+wKfuMajg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.1.tgz",
+      "integrity": "sha512-Js16gOgU6Qht6qTPfuJgb+1YD4AEO+5Y1UPGWKSp3BNo8ONl/qhXSYDhFKJtwybRJynlCqvP5IeiaBsUmkSPTQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.0.0",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.1",
+        "@smithy/node-http-handler": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-uri-escape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
       "dev": true,
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-waiter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.0.tgz",
-      "integrity": "sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.2.tgz",
+      "integrity": "sha512-piUTHyp2Axx3p/kc2CIJkYSv0BAaheBQmbACZgQSSfWUumWNW+R1lL+H9PDBxKJkvOeEX+hKYEFiwO8xagL8AQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/abort-controller": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/abort-controller": "^4.0.1",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/uuid": {
@@ -9454,9 +9977,9 @@
       }
     },
     "node_modules/@hapi/bounce": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.1.tgz",
-      "integrity": "sha512-G+/Pp9c1Ha4FDP+3Sy/Xwg2O4Ahaw3lIZFSX+BL4uWi64CmiETuZPxhKDUD4xBMOUZbBlzvO8HjiK8ePnhBadA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.2.tgz",
+      "integrity": "sha512-d0XmlTi3H9HFDHhQLjg4F4auL1EY3Wqj7j7/hGDhFFe6xAbnm3qiGrXeT93zZnPH8gH+SKAFYiRzu26xkXcH3g==",
       "dev": true,
       "dependencies": {
         "@hapi/boom": "^10.0.1",
@@ -9492,9 +10015,9 @@
       }
     },
     "node_modules/@hapi/catbox-memory": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.1.tgz",
-      "integrity": "sha512-sVb+/ZxbZIvaMtJfAbdyY+QJUQg9oKTwamXpEg/5xnfG5WbJLTjvEn4kIGKz9pN3ENNbIL/bIdctmHmqi/AdGA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.2.tgz",
+      "integrity": "sha512-H1l4ugoFW/ZRkqeFrIo8p1rWN0PA4MDTfu4JmcoNDvnY975o29mqoZblqFTotxNHlEkMPpIiIBJTV+Mbi+aF0g==",
       "dev": true,
       "dependencies": {
         "@hapi/boom": "^10.0.1",
@@ -9544,20 +10067,20 @@
       }
     },
     "node_modules/@hapi/hapi": {
-      "version": "21.3.9",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.9.tgz",
-      "integrity": "sha512-AT5m+Rb8iSOFG3zWaiEuTJazf4HDYl5UpRpyxMJ3yR+g8tOEmqDv6FmXrLHShdvDOStAAepHGnr1G7egkFSRdw==",
+      "version": "21.3.12",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.12.tgz",
+      "integrity": "sha512-GCUP12dkb3QMjpFl+wEFO73nqKRmsnD5um/QDOn6lj2GjGBrDXPcT194mNARO+PPNXZOR4KmvIpHt/lceUncfg==",
       "dev": true,
       "dependencies": {
-        "@hapi/accept": "^6.0.1",
+        "@hapi/accept": "^6.0.3",
         "@hapi/ammo": "^6.0.1",
         "@hapi/boom": "^10.0.1",
-        "@hapi/bounce": "^3.0.1",
+        "@hapi/bounce": "^3.0.2",
         "@hapi/call": "^9.0.1",
         "@hapi/catbox": "^12.1.1",
-        "@hapi/catbox-memory": "^6.0.1",
+        "@hapi/catbox-memory": "^6.0.2",
         "@hapi/heavy": "^8.0.1",
-        "@hapi/hoek": "^11.0.2",
+        "@hapi/hoek": "^11.0.6",
         "@hapi/mimos": "^7.0.1",
         "@hapi/podium": "^5.0.1",
         "@hapi/shot": "^6.0.1",
@@ -9565,7 +10088,7 @@
         "@hapi/statehood": "^8.1.1",
         "@hapi/subtext": "^8.1.0",
         "@hapi/teamwork": "^6.0.0",
-        "@hapi/topo": "^6.0.1",
+        "@hapi/topo": "^6.0.2",
         "@hapi/validate": "^2.0.1"
       },
       "engines": {
@@ -9584,9 +10107,9 @@
       }
     },
     "node_modules/@hapi/hoek": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.2.tgz",
-      "integrity": "sha512-aKmlCO57XFZ26wso4rJsW4oTUnrgTFw2jh3io7CAtO9w4UltBNwRXvXIVzzyfkaaLRo3nluP/19msA8vDUUuKw==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
       "dev": true
     },
     "node_modules/@hapi/iron": {
@@ -9639,9 +10162,9 @@
       }
     },
     "node_modules/@hapi/podium": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.1.tgz",
-      "integrity": "sha512-eznFTw6rdBhAijXFIlBOMJJd+lXTvqbrBIS4Iu80r2KTVIo4g+7fLy4NKp/8+UnSt5Ox6mJtAlKBU/Sf5080TQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.2.tgz",
+      "integrity": "sha512-T7gf2JYHQQfEfewTQFbsaXoZxSvuXO/QBIGljucUQ/lmPnTTNAepoIKOakWNVWvo2fMEDjycu77r8k6dhreqHA==",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^11.0.2",
@@ -9870,10 +10393,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "dev": true,
       "engines": {
         "node": ">= 10.16.0"
@@ -9883,9 +10418,9 @@
       }
     },
     "node_modules/@jsep-plugin/ternary": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.3.tgz",
-      "integrity": "sha512-qtLGzCNzPVJ3kdH6/zoLWDPjauHIKiLSBAR71Wa0+PWvGA8wODUQvRgxtpUA5YqAYL3CQ8S4qXhd/9WuWTZirg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.4.tgz",
+      "integrity": "sha512-ck5wiqIbqdMX6WRQztBL7ASDty9YLgJ3sSAK5ZpBzXeySvFGCzIvM6UiAI4hTZ22fEcYQVV/zhUbNscggW+Ukg==",
       "dev": true,
       "engines": {
         "node": ">= 10.16.0"
@@ -12460,35 +12995,35 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.18.3.tgz",
-      "integrity": "sha512-YY8x7X2SWJIhGTLPol+eFiQpWPz0D0mJdkK2i4A0QJG68KkNhypP6+JBC7/Kz3XWjqr0L/RqAd+N5cQLPOKZGQ==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.4.tgz",
+      "integrity": "sha512-8hnZXfssTlV99SKo8J8BwMt5LsiBFHkCh0V3P7j8IPcCNl//bpG92U4TpYy7AwmUms/zCLX7sxNQC6AZ+bkfzg==",
       "dev": true,
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "~3.21.0",
         "@stoplight/path": "1.3.2",
         "@stoplight/spectral-parsers": "^1.0.0",
-        "@stoplight/spectral-ref-resolver": "^1.0.0",
-        "@stoplight/spectral-runtime": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "~13.6.0",
         "@types/es-aggregate-error": "^1.0.2",
         "@types/json-schema": "^7.0.11",
-        "ajv": "^8.6.0",
+        "ajv": "^8.17.1",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "es-aggregate-error": "^1.0.7",
-        "jsonpath-plus": "7.1.0",
+        "jsonpath-plus": "10.2.0",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
         "minimatch": "3.1.2",
-        "nimma": "0.2.2",
-        "pony-cause": "^1.0.0",
-        "simple-eval": "1.0.0",
-        "tslib": "^2.3.0"
+        "nimma": "0.2.3",
+        "pony-cause": "^1.1.1",
+        "simple-eval": "1.0.1",
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/@stoplight/better-ajv-errors": {
@@ -12521,15 +13056,15 @@
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -12550,15 +13085,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
-    },
-    "node_modules/@stoplight/spectral-core/node_modules/jsonpath-plus": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.1.0.tgz",
-      "integrity": "sha512-gTaNRsPWO/K2KY6MrqaUFClF9kmuM6MFH5Dhg1VYDODgFbByw1yb7xu3hrViE/sz+dGOeMWgCzwUwQtAnCTE9g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/@stoplight/spectral-core/node_modules/jsonpointer": {
       "version": "5.0.1",
@@ -13170,18 +13696,18 @@
       }
     },
     "node_modules/@types/eslint-scope": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.6.tgz",
-      "integrity": "sha512-zfM4ipmxVKWdxtDaJ3MP3pBurDXOCoyjvlpE3u6Qzrmw4BPbfm4/ambIeTk/r/J0iq/+2/xp0Fmt+gFvXJY2PQ==",
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -13583,133 +14109,133 @@
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ=="
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA=="
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA=="
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ=="
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -13807,22 +14333,14 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -14664,12 +15182,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -14799,9 +15317,9 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -14811,7 +15329,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -14889,20 +15407,20 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "funding": [
         {
           "type": "opencollective",
@@ -14918,10 +15436,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -15066,9 +15584,37 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15154,9 +15700,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001551",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz",
-      "integrity": "sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==",
+      "version": "1.0.30001692",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
+      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
       "funding": [
         {
           "type": "opencollective",
@@ -15216,9 +15762,9 @@
       }
     },
     "node_modules/child-process-ext/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -15923,9 +16469,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -16093,9 +16639,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -16639,9 +17185,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
-      "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ=="
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw=="
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
@@ -16662,6 +17208,19 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duration": {
@@ -16686,9 +17245,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.559",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.559.tgz",
-      "integrity": "sha512-iS7KhLYCSJbdo3rUSkhDTVuFNCV34RKs2UaB9Ecr7VlqzjjWW//0nfsFF5dtDmyXlZQaDYYtID5fjtC/6lpRug=="
+      "version": "1.5.80",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.80.tgz",
+      "integrity": "sha512-LTrKpW0AqIuHwmlVNV+cjFYTnXtM9K37OGhpe0ZI10ScPSxqVSryZHIY3WnCS5NSYbBODRTZyhRMS2h5FAEqAw=="
     },
     "node_modules/emittery": {
       "version": "1.0.1",
@@ -16714,9 +17273,9 @@
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -16731,9 +17290,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
-      "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -16829,6 +17388,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-iterator-helpers": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz",
@@ -16856,6 +17431,17 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.1.tgz",
       "integrity": "sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q=="
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.0.1",
@@ -16984,9 +17570,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
@@ -17699,36 +18285,36 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -17737,6 +18323,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -17848,6 +18438,22 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
+      "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",
@@ -18008,9 +18614,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -18019,12 +18625,12 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -18349,14 +18955,23 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18366,6 +18981,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.1.tgz",
       "integrity": "sha512-3UBAyM3u4ZBVYDsxOQfJDxEa6XTbpBDrOjp4mf7ExFRt5BKs/QywQQiJsh2B+hxcZLSapWqCRvElUe8DnKcFHA=="
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/get-source": {
       "version": "2.0.12",
@@ -18541,12 +19168,11 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18637,6 +19263,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
       "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -18695,6 +19322,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -18703,9 +19331,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -18729,10 +19357,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -19810,9 +20437,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.1.tgz",
-      "integrity": "sha512-qiaQhtQRw6YrOaOj0v59h3R6hUY9NvxBmmnMfKemkqYmBB0tEc97NbLP7ix44VP5p9/0YHG8Vyhzuo5YBNwviA==",
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -19861,9 +20488,9 @@
       }
     },
     "node_modules/jsep": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
-      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "engines": {
         "node": ">= 10.16.0"
@@ -20063,12 +20690,21 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-8.0.0.tgz",
-      "integrity": "sha512-+AOBHcQvRr8DcWVIkfOCCCLSlYgQuNZ+gFNqwkBrNpdUfdfkcrbO4ml3F587fWUMFOmoy6D9c+5wrghgjN3mbg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
       "dev": true,
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonschema": {
@@ -20657,9 +21293,9 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "node_modules/luxon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -20768,6 +21404,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/md5-hex": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
@@ -20835,9 +21479,12 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -20862,11 +21509,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -21108,9 +21755,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -21178,9 +21825,9 @@
       "dev": true
     },
     "node_modules/nimma": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.2.tgz",
-      "integrity": "sha512-V52MLl7BU+tH2Np9tDrIXK8bql3MVUadnMIl/0/oZSGC9keuro0O9UUv9QKp0aMvtN8HRew4G7byY7H4eWsxaQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
+      "integrity": "sha512-1ZOI8J+1PKKGceo/5CT5GfQOG6H8I2BencSK06YarZ2wXwH37BSSUWldqJmMJYA5JfqDqffxDXynt6f11AyKcA==",
       "dev": true,
       "dependencies": {
         "@jsep-plugin/regex": "^1.0.1",
@@ -21192,18 +21839,8 @@
         "node": "^12.20 || >=14.13"
       },
       "optionalDependencies": {
-        "jsonpath-plus": "^6.0.1",
+        "jsonpath-plus": "^6.0.1 || ^10.1.0",
         "lodash.topath": "^4.5.2"
-      }
-    },
-    "node_modules/nimma/node_modules/jsonpath-plus": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
-      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/nise": {
@@ -21235,9 +21872,9 @@
       "dev": true
     },
     "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
@@ -21308,9 +21945,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
     },
     "node_modules/node-sarif-builder": {
       "version": "2.0.3",
@@ -21547,9 +22184,12 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.0.tgz",
-      "integrity": "sha512-HQ4J+ic8hKrgIt3mqk6cVOVrW2ozL4KdvHlqpBv9vDYWx9ysAgENAdvy4FoGF+KFdhR7nQTNm5J0ctAeOwn+3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -22142,9 +22782,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -22184,6 +22824,11 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz",
       "integrity": "sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g=="
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -22979,11 +23624,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -23466,9 +24111,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -23722,9 +24367,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -23756,6 +24401,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
@@ -23793,14 +24446,14 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -23887,16 +24540,15 @@
       }
     },
     "node_modules/serverless-offline": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.5.0.tgz",
-      "integrity": "sha512-t+xyBTjYBtkyywrP3UnhNFFxQ03QflIn/20ImW3BnkSYr/5Sl6yX6coHoYx7X5QoVaOeHIAROs+WID0WR/IKyQ==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.9.0.tgz",
+      "integrity": "sha512-r/GU1FcgUbrhUzPJ5BOpni6JXhHVhxksYQH8d3S4alx4IZQo3E9Q8fT2z8Mvh+d0rfQ1Y0kHvyeKJ126rleGfg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-lambda": "^3.509.0",
+        "@aws-sdk/client-lambda": "^3.636.0",
         "@hapi/boom": "^10.0.1",
         "@hapi/h2o2": "^10.0.4",
-        "@hapi/hapi": "^21.3.3",
-        "@serverless/utils": "^6.15.0",
+        "@hapi/hapi": "^21.3.10",
         "array-unflat-js": "^0.1.3",
         "boxen": "^7.1.1",
         "chalk": "^5.3.0",
@@ -23905,16 +24557,16 @@
         "fs-extra": "^11.2.0",
         "is-wsl": "^3.1.0",
         "java-invoke-local": "0.0.6",
-        "jose": "^5.2.1",
+        "jose": "^5.7.0",
         "js-string-escape": "^1.0.1",
-        "jsonpath-plus": "^8.0.0",
+        "jsonpath-plus": "^10.2.0",
         "jsonschema": "^1.4.1",
         "jszip": "^3.10.1",
-        "luxon": "^3.4.4",
+        "luxon": "^3.5.0",
         "node-schedule": "^2.1.1",
         "p-memoize": "^7.1.1",
         "velocityjs": "^2.0.6",
-        "ws": "^8.16.0"
+        "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -23953,9 +24605,9 @@
       }
     },
     "node_modules/serverless-offline/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -24208,13 +24860,68 @@
       "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -24227,12 +24934,12 @@
       "dev": true
     },
     "node_modules/simple-eval": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.0.tgz",
-      "integrity": "sha512-kpKJR+bqTscgC0xuAl2xHN6bB12lHjC2DCUfqjAx19bQyO3R2EVLOurm3H9AUltv/uFVcSCVNc6faegR+8NYLw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.1.tgz",
+      "integrity": "sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==",
       "dev": true,
       "dependencies": {
-        "jsep": "^1.1.2"
+        "jsep": "^1.3.6"
       },
       "engines": {
         "node": ">=12"
@@ -24834,11 +25541,6 @@
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0"
       }
-    },
-    "node_modules/styled-components/node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/styled-components/node_modules/postcss": {
       "version": "8.4.31",
@@ -25598,9 +26300,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type": {
       "version": "2.7.2",
@@ -25844,9 +26546,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -25862,8 +26564,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -25871,11 +26573,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/update-browserslist-db/node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -26085,20 +26782,19 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.91.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-      "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.21.10",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.16.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -26555,9 +27251,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },

--- a/src/lambdas/api/openapi.yaml
+++ b/src/lambdas/api/openapi.yaml
@@ -96,6 +96,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/bbox'
         - $ref: '#/components/parameters/datetime'
+        - $ref: '#/components/parameters/query'
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/filter-lang'
         - $ref: '#/components/parameters/filter-crs'
@@ -2126,7 +2127,6 @@ components:
         **Extension:** Query
 
         Query for properties in items.
-        Use the JSON form of the query used in POST.
       required: false
       schema:
         type: string

--- a/src/lambdas/api/openapi.yaml
+++ b/src/lambdas/api/openapi.yaml
@@ -292,6 +292,10 @@ paths:
         - $ref: '#/components/parameters/collectionsArray'
         - $ref: '#/components/parameters/fields'
         - $ref: '#/components/parameters/sortby'
+        - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/filter-lang'
+        - $ref: '#/components/parameters/filter-crs'
       responses:
         '200':
           description: A feature collection.
@@ -326,8 +330,6 @@ paths:
             schema:
               allOf:
                 - $ref: '#/components/schemas/searchBody'
-                - $ref: '#/components/schemas/schemas-searchBody'
-                - $ref: '#/components/schemas/openapi_components-schemas-searchBody'
       responses:
         '200':
           description: A feature collection.
@@ -1318,6 +1320,10 @@ components:
         - $ref: '#/components/schemas/collectionsFilter'
         - $ref: '#/components/schemas/idsFilter'
         - $ref: '#/components/schemas/limitFilter'
+        - $ref: '#/components/schemas/fieldsFilter'
+        - $ref: '#/components/schemas/sortFilter'
+        - $ref: '#/components/schemas/queryFilter'
+        - $ref: '#/components/schemas/filterFilter'
     limit:
       type: integer
       minimum: 1
@@ -1479,7 +1485,7 @@ components:
         exclude:
           - geometry
           - properties.datetime
-    schemas-searchBody:
+    fieldsFilter:
       type: object
       x-stac-api-fragment: fields
       description: |-
@@ -1513,7 +1519,7 @@ components:
           direction: asc
         - field: id
           direction: desc
-    openapi_components-schemas-searchBody:
+    sortFilter:
       type: object
       x-stac-api-fragment: sort
       description: |-
@@ -1523,6 +1529,132 @@ components:
       properties:
         sortby:
           $ref: '#/components/schemas/sortby'
+    queryFilter:
+      type: object
+      x-stac-api-fragment: query
+      description: |-
+        **Extension:** Query
+
+        Allows users to query properties for specific values
+      properties:
+        query:
+          $ref: '#/components/schemas/query'
+    query:
+      type: object
+      description: Define which properties to query and the operations to apply
+      additionalProperties:
+        $ref: '#/components/schemas/queryProp'
+      example:
+        eo:cloud_cover:
+          gt: 8
+          lt: 50
+        platform:
+          eq: 'landsat-8'
+        datetime:
+          gte: '2018-02-12T00:00:00Z'
+          lte: '2018-03-18T12:31:12Z'
+        pl:item_type:
+          startsWith: PSScene
+        product:
+          in:
+            - foo
+            - bar
+            - baz
+        eo:gsd:
+          in:
+            - 10
+            - 20
+    queryProp:
+      description: Apply query operations to a specific property
+      anyOf:
+        - description: if the object doesn't contain any of the operators, it is equivalent to using the equals operator
+        - type: object
+          description: Match using an operator
+          properties:
+            eq:
+              description: Find items with a property that is equal to the specified value. For strings, a case-insensitive comparison must be performed.
+              nullable: true
+              oneOf:
+                - type: string
+                - type: number
+                - type: boolean
+            neq:
+              description: Find items that *don't* contain the specified value. For strings, a case-insensitive comparison must be performed.
+              nullable: true
+              oneOf:
+                - type: string
+                - type: number
+                - type: boolean
+            gt:
+              description: Find items with a property value greater than the specified value.
+              oneOf:
+                - type: string
+                  format: date-time
+                - type: number
+            lt:
+              description: Find items with a property value less than the specified value.
+              oneOf:
+                - type: string
+                  format: date-time
+                - type: number
+            gte:
+              description: Find items with a property value greater than or equal the specified value.
+              oneOf:
+                - type: string
+                  format: date-time
+                - type: number
+            lte:
+              description: Find items with a property value less than or equal the specified value.
+              oneOf:
+                - type: string
+                  format: date-time
+                - type: number
+            startsWith:
+              description: Find items with a property that begins with the specified string. A case-insensitive comparison must be performed.
+              type: string
+            endsWith:
+              description: Find items with a property that ends with the specified string. A case-insensitive comparison must be performed.
+              type: string
+            contains:
+              description: Find items with a property that contains the specified literal string, e.g., matches ".*<STRING>.*". A case-insensitive comparison must be performed.
+              type: string
+            in:
+              description: Find items with a property that equals at least one entry in the specified array. A case-insensitive comparison must be performed.
+              type: array
+              items:
+                oneOf:
+                  - type: string
+                  - type: number
+    filterFilter:
+      type: object
+      x-stac-api-fragment: filter
+      description: |-
+        **Extension:** Filter
+
+        A filter for properties in Items.
+      allOf: # Combines the searchBody of Item-filter and the inline model
+        - $ref: 'https://api.stacspec.org/v1.0.0/item-search/openapi.yaml#/components/schemas/searchBody'
+      properties:
+        filter:
+          $ref: '#/components/schemas/filter-cql2-json'
+        filter-lang:
+          $ref: '#/components/schemas/filter-lang'
+        filter-crs:
+          $ref: '#/components/schemas/filter-crs'
+    filter-cql2-json:
+      $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/cql2/standard/schema/cql2.yml#/components/schemas/booleanExpression'
+    filter-lang:
+      description: |
+        The CQL2 filter encoding that the 'filter' value uses.
+      type: string
+      default: 'cql2-json'
+    filter-crs:
+      description: |
+        The coordinate reference system (CRS) used by spatial literals in the 'filter' value.  The only value that STAC APIs must
+        accept is 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'.
+      type: string
+      format: uri
+      default: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
   responses:
     LandingPage:
       description: |-
@@ -1936,3 +2068,49 @@ components:
         example: +id,-properties.eo:cloud_cover
       style: form
       explode: false
+    query:
+      name: query
+      x-stac-api-fragment: query
+      in: query
+      description: |-
+        **Extension:** Query
+
+        Query for properties in items.
+        Use the JSON form of the query used in POST.
+      required: false
+      schema:
+        type: string
+    filter:
+      name: filter
+      x-stac-api-fragment: filter
+      in: query
+      description: |-
+        **Extension:** Filter
+
+        A CQL2 filter expression for filtering items. Use the JSON form of the filter used in POST.
+      required: false
+      schema:
+        oneOf:
+          - $ref: '#/components/schemas/filter-cql2-json'
+    filter-lang:
+      name: filter-lang
+      x-stac-api-fragment: filter
+      in: query
+      description: |-
+        **Extension:** Filter
+
+        The CQL2 filter encoding that the 'filter' value uses. Only 'cql2-json' is supported.
+      required: false
+      schema:
+        $ref: '#/components/schemas/filter-lang'
+    filter-crs:
+      name: filter-crs
+      x-stac-api-fragment: filter
+      in: query
+      description: |-
+        **Extension:** Filter
+
+        The CRS used by spatial predicates in the filter parameter. Only 'http://www.opengis.net/def/crs/OGC/1.3/CRS84' is supported.
+      required: false
+      schema:
+        $ref: '#/components/schemas/filter-crs'

--- a/src/lambdas/api/openapi.yaml
+++ b/src/lambdas/api/openapi.yaml
@@ -22,7 +22,7 @@ paths:
     get:
       tags:
         - Features
-      summary: landing page
+      summary: Landing page
       description: >-
         The landing page provides links to the sub-resources.
       operationId: getLandingPage
@@ -35,7 +35,7 @@ paths:
     get:
       tags:
         - Features
-      summary: the feature collections in the dataset
+      summary: Get the feature collections in the dataset
       description: >-
         A body of Feature Collections that belong or are used together with additional links.
 
@@ -50,7 +50,7 @@ paths:
     get:
       tags:
         - Features
-      summary: describe the feature collection with id `collectionId`
+      summary: Describe the feature collection with Id `collectionId`
       description: >-
         A single Feature Collection for the given if `collectionId`.
 
@@ -69,7 +69,7 @@ paths:
     get:
       tags:
         - Features
-      summary: information about specifications that this API conforms to
+      summary: Get information about specifications this API conforms to
       description: |-
         A list of all conformance classes specified in a standard that the
         server conforms to.
@@ -83,7 +83,7 @@ paths:
     get:
       tags:
         - Features
-      summary: fetch features
+      summary: Fetch features
       description: |-
         Fetch features of the feature collection with id `collectionId`.
 
@@ -96,6 +96,9 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/bbox'
         - $ref: '#/components/parameters/datetime'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/filter-lang'
+        - $ref: '#/components/parameters/filter-crs'
       responses:
         '200':
           $ref: '#/components/responses/Features'
@@ -108,7 +111,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/collectionId'
     post:
-      summary: add a new STAC Item to a collection
+      summary: Add a new STAC Item to a collection
       description: create a new STAC Item in a specific collection
       operationId: postFeature
       tags:
@@ -154,7 +157,7 @@ paths:
     get:
       tags:
         - Transaction
-      summary: fetch a single feature
+      summary: Fetch a single feature
       description: |-
         Fetch the feature with id `featureId` in the feature collection
         with id `collectionId`.
@@ -173,7 +176,7 @@ paths:
       - $ref: '#/components/parameters/collectionId'
       - $ref: '#/components/parameters/featureId'
     put:
-      summary: update an existing feature by Id with a complete item definition
+      summary: Update an existing feature by Id with a complete item definition
       description: >-
         Use this method to update an existing feature. Requires the entire GeoJSON  description be submitted.
       operationId: updateFeature
@@ -211,7 +214,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/exception'
     patch:
-      summary: update an existing feature by Id with a partial item definition
+      summary: Update an existing feature by Id with a partial item definition
       description: >-
         Use this method to update an existing feature. Requires a GeoJSON fragment (containing the fields to be updated) be submitted.
       operationId: patchFeature
@@ -245,7 +248,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/exception'
     delete:
-      summary: delete an existing feature by Id
+      summary: Delete an existing feature by Id
       description: Use this method to delete an existing feature.
       operationId: deleteFeature
       tags:
@@ -269,7 +272,7 @@ paths:
                 $ref: '#/components/schemas/exception'
   /search:
     get:
-      summary: Search STAC items with simple filtering.
+      summary: Search STAC items with simple filtering
       operationId: getItemSearch
       description: |-
         Retrieve Items matching filters. Intended as a shorthand API for simple
@@ -304,14 +307,14 @@ paths:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/itemCollection'
-                  - $ref: '#/components/schemas/schemas-itemCollection'
+                  - $ref: '#/components/schemas/context'
             text/html:
               schema:
                 type: string
         default:
           $ref: '#/components/responses/Error'
     post:
-      summary: Search STAC items with full-featured filtering.
+      summary: Search STAC items with full-featured filtering
       operationId: postItemSearch
       description: |-
         Retrieve items matching filters. Intended as the standard, full-featured
@@ -336,10 +339,44 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: '#/components/schemas/itemCollection'
+                allOf:
+                  - $ref: '#/components/schemas/itemCollection'
+                  - $ref: '#/components/schemas/context'
             text/html:
               schema:
                 type: string
+        default:
+          $ref: '#/components/responses/Error'
+  /queryables:
+    get:
+      summary: Get the JSON Schema defining the list of variable terms that can be used in CQL2 expressions
+      operationId: getQueryables
+      description: |-
+        This endpoint returns a list of variable terms that can be used in CQL2 expressions. The
+        precise definition of this can be found in the OGC API - Features - Part 3: Filtering and the
+        Common Query Language (CQL2) specification.
+      tags:
+        - Item Search
+      responses:
+        '200':
+          $ref: '#/components/responses/Queryables'
+        default:
+          $ref: '#/components/responses/Error'
+  /collections/{collectionId}/queryables:
+    get:
+      summary: Get the JSON Schema defining the list of variable terms that can be used in CQL2 expressions
+      operationId: getQueryablesForCollection
+      description: |-
+        This endpoint returns a list of variable terms that can be used in CQL2 expressions. The
+        precise definition of this can be found in the OGC API - Features - Part 3: Filtering and the
+        Common Query Language (CQL) specification.
+      parameters:
+        - $ref: '#/components/parameters/collectionId'
+      tags:
+        - Features
+      responses:
+        '200':
+          $ref: '#/components/responses/Queryables'
         default:
           $ref: '#/components/responses/Error'
 components:
@@ -860,6 +897,9 @@ components:
               https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
             title: >-
               Legal notice on the use of Copernicus Sentinel Data and Service Information
+          - rel: queryables
+            href: http://cool-sat.com/collections/Sentinel-2/queryables
+            title: queryables for this collection
     featureCollectionGeoJSON:
       allOf:
         - $ref: '#/components/schemas/schemas-featureCollectionGeoJSON'
@@ -1434,7 +1474,7 @@ components:
         - 39.5
         - -105
         - 40.5
-    schemas-itemCollection:
+    context:
       type: object
       description: >-
         **Extension:** Context
@@ -1695,6 +1735,10 @@ components:
                 rel: child
                 type: application/json
                 title: Sentinel 2 Catalog
+              - href: http://data.example.org/queryables
+                rel: queryables
+                type: application/json
+                title: queryables for entire catalog
     Error:
       description: An error occurred.
       content:
@@ -1852,6 +1896,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/exception'
+    Queryables:
+      description: A JSON Schema defining the Queryables allowed in CQL2 expressions
+      content:
+        application/schema+json:
+          schema:
+            type: object
   parameters:
     collectionId:
       name: collectionId
@@ -2087,7 +2137,7 @@ components:
       description: |-
         **Extension:** Filter
 
-        A CQL2 filter expression for filtering items. Use the JSON form of the filter used in POST.
+        A CQL2 filter expression for filtering items.
       required: false
       schema:
         oneOf:

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -268,8 +268,9 @@ const extractCql2Filter = function (params) {
   let cql2Filter
   const { filter } = params
   if (filter) {
-    if (typeof filter !== 'object') {
-      throw new ValidationError('Invalid filter value, must be a JSON object')
+    if (typeof filter === 'string') {
+      const parsed = JSON.parse(filter)
+      cql2Filter = parsed
     } else {
       cql2Filter = { ...filter }
     }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -757,6 +757,7 @@ const aggregate = async function (
   const intersectsGeometry = extractIntersects(queryParameters)
   const geometry = intersectsGeometry || bboxGeometry
   const query = extractStacQuery(queryParameters)
+  const filter = extractCql2Filter(queryParameters)
   const ids = extractIds(queryParameters)
   const collections = extractCollectionIds(queryParameters)
 
@@ -764,6 +765,7 @@ const aggregate = async function (
     datetime,
     intersects: geometry,
     query,
+    filter,
     ids,
     collections,
   })
@@ -980,8 +982,10 @@ const getConformance = async function (txnEnabled) {
     'https://api.stacspec.org/v1.0.0/item-search#fields',
     'https://api.stacspec.org/v1.0.0/item-search#sort',
     'https://api.stacspec.org/v1.0.0/item-search#query',
-    'https://api.stacspec.org/v0.3.0/aggregation',
     'https://api.stacspec.org/v1.0.0/item-search#filter',
+    'https://api.stacspec.org/v0.3.0/aggregation',
+    'https://api.stacspec.org/v0.3.0/aggregation#query',
+    'https://api.stacspec.org/v0.3.0/aggregation#filter',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -264,6 +264,19 @@ const extractStacQuery = function (params) {
   return stacQuery
 }
 
+const extractCql2Filter = function (params) {
+  let cql2Filter
+  const { filter } = params
+  if (filter) {
+    if (typeof filter !== 'object') {
+      throw new ValidationError('Invalid filter value, must be a JSON object')
+    } else {
+      cql2Filter = { ...filter }
+    }
+  }
+  return cql2Filter
+}
+
 const extractSortby = function (params) {
   let sortbyRules
   const { sortby } = params
@@ -588,10 +601,15 @@ const searchItems = async function (collectionId, queryParameters, backend, endp
     next,
     bbox,
     intersects
+    // query_,
+    // filter_
   } = queryParameters
   if (bbox && intersects) {
     throw new ValidationError('Expected bbox OR intersects, not both')
   }
+  // if (query_ && filter_) {
+  //   throw new ValidationError('Expected query OR filter, not both')
+  // }
   const datetime = extractDatetime(queryParameters)
   const bboxGeometry = extractBbox(queryParameters, httpMethod)
   const intersectsGeometry = extractIntersects(queryParameters)
@@ -599,6 +617,7 @@ const searchItems = async function (collectionId, queryParameters, backend, endp
 
   const sortby = extractSortby(queryParameters)
   const query = extractStacQuery(queryParameters)
+  const filter = extractCql2Filter(queryParameters)
   const fields = extractFields(queryParameters)
   const ids = extractIds(queryParameters)
   const collections = extractCollectionIds(queryParameters)
@@ -609,6 +628,7 @@ const searchItems = async function (collectionId, queryParameters, backend, endp
     datetime,
     intersects: geometry,
     query,
+    filter,
     sortby,
     fields,
     ids,

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -266,7 +266,20 @@ const extractStacQuery = function (params) {
 
 const extractCql2Filter = function (params) {
   let cql2Filter
-  const { filter } = params
+  const { 'filter-lang': filterLang, 'filter-crs': filterCrs, filter } = params
+
+  if (filterLang && filterLang !== 'cql2-json') {
+    throw new ValidationError(
+      `filter-lang must be "cql2-json". Supplied value: ${filterLang}`
+    )
+  }
+
+  if (filterCrs && filterCrs !== 'http://www.opengis.net/def/crs/OGC/1.3/CRS84') {
+    throw new ValidationError(
+      `filter-crs must be "http://www.opengis.net/def/crs/OGC/1.3/CRS84". Supplied value: ${filterCrs}`
+    )
+  }
+
   if (filter) {
     if (typeof filter === 'string') {
       const parsed = JSON.parse(filter)

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -601,15 +601,10 @@ const searchItems = async function (collectionId, queryParameters, backend, endp
     next,
     bbox,
     intersects
-    // query_,
-    // filter_
   } = queryParameters
   if (bbox && intersects) {
     throw new ValidationError('Expected bbox OR intersects, not both')
   }
-  // if (query_ && filter_) {
-  //   throw new ValidationError('Expected query OR filter, not both')
-  // }
   const datetime = extractDatetime(queryParameters)
   const bboxGeometry = extractBbox(queryParameters, httpMethod)
   const intersectsGeometry = extractIntersects(queryParameters)

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -952,9 +952,13 @@ const getConformance = async function (txnEnabled) {
     'https://api.stacspec.org/v1.0.0/item-search#sort',
     'https://api.stacspec.org/v1.0.0/item-search#query',
     'https://api.stacspec.org/v0.3.0/aggregation',
+    'https://api.stacspec.org/v1.0.0/item-search#filter',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
-    'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson'
+    'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',
+    'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter',
+    'http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2',
+    'http://www.opengis.net/spec/cql2/1.0/conf/cql2-json'
   ]
 
   if (txnEnabled) {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1017,6 +1017,17 @@ const getGlobalQueryables = async (endpoint = '') => ({
   additionalProperties: true
 })
 
+const validateAdditionalProperties = (queryables) => {
+  if ('additionalProperties' in queryables) {
+    const additionalProperties = queryables.additionalProperties
+    if (additionalProperties !== true) {
+      throw new ValidationError(
+        `Unsupported additionalProperties value: "${additionalProperties}". Must be set to "true".`
+      )
+    }
+  }
+}
+
 const getCollectionQueryables = async (collectionId, backend, endpoint = '') => {
   const collection = await backend.getCollection(collectionId)
 
@@ -1024,6 +1035,7 @@ const getCollectionQueryables = async (collectionId, backend, endpoint = '') => 
     return collection
   }
   const queryables = collection.queryables || { ...DEFAULT_QUERYABLES }
+  validateAdditionalProperties(queryables)
   queryables.$id = `${endpoint}/collections/${collectionId}/queryables`
   queryables.title = `Queryables for Collection ${collectionId}`
   return queryables

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -320,12 +320,12 @@ function buildQuery(parameters) {
   const { query, filter, intersects, collections, ids } = parameters
 
   let cql2Query = {}
-  let stacQlQuery = {}
+  let stacqlQuery = {}
   let itemSearchQuery = {}
   const osQuery = { bool: {} }
 
   if (query) {
-    stacQlQuery = buildQueryExtQuery(query)
+    stacqlQuery = buildQueryExtQuery(query)
   }
 
   if (filter) {
@@ -342,7 +342,7 @@ function buildQuery(parameters) {
 
   const combinedFilter = [
     ...(cql2Query.bool?.filter || []),
-    ...(stacQlQuery.bool?.filter || []),
+    ...(stacqlQuery.bool?.filter || []),
     ...(itemSearchQuery.bool?.filter || [])
   ]
   const combinedShould = [
@@ -350,7 +350,7 @@ function buildQuery(parameters) {
   ]
   const combinedMustNot = [
     ...(cql2Query.bool?.must_not || []),
-    ...(stacQlQuery.bool?.must_not || []),
+    ...(stacqlQuery.bool?.must_not || []),
   ]
 
   if (!isEmpty(combinedFilter)) {

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -316,7 +316,7 @@ function buildItemSearchQuery(parameters) {
   }
 }
 
-function buildQuery(parameters) {
+function buildOpenSearchQuery(parameters) {
   const { query, filter, intersects, collections, ids } = parameters
 
   let cql2Query = {}
@@ -626,7 +626,7 @@ export async function constructSearchParams(parameters, page, limit) {
   if (id) {
     body = buildIdQuery(id)
   } else {
-    body = buildQuery(parameters)
+    body = buildOpenSearchQuery(parameters)
     body.sort = buildSort(parameters) // sort applied to the id query causes hang???
     body.search_after = buildSearchAfter(parameters)
   }

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -24,6 +24,12 @@ const RANGE_TRANSLATION = {
   '>': 'gt',
   '>=': 'gte'
 }
+const UNPREFIXED_FIELDS = [
+  'id',
+  'collection',
+  'geometry',
+  'bbox'
+]
 
 let collectionToIndexMapping = null
 let unrestrictedIndices = null
@@ -195,7 +201,10 @@ function buildQueryExtQuery(query) {
 }
 
 function buildFilterExtQuery(filter) {
-  const cql2Field = filter.args[0].property
+  let cql2Field = filter.args[0].property
+  if (!UNPREFIXED_FIELDS.includes(cql2Field)) {
+    cql2Field = `properties.${cql2Field}`
+  }
 
   let cql2Value = filter.args[1]
   if (typeof cql2Value === 'object' && cql2Value.timestamp) {

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -28,7 +28,6 @@ const UNPREFIXED_FIELDS = [
   'id',
   'collection',
   'geometry',
-  'bbox'
 ]
 
 let collectionToIndexMapping = null

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -213,7 +213,8 @@ function buildFilterExtQuery(filter) {
   case LOGICAL_OP.OR:
     return {
       bool: {
-        should: filter.args.map(buildFilterExtQuery)
+        should: filter.args.map(buildFilterExtQuery),
+        minimum_should_match: 1
       }
     }
   case LOGICAL_OP.NOT:
@@ -358,6 +359,7 @@ function buildOpenSearchQuery(parameters) {
   }
   if (!isEmpty(combinedShould)) {
     osQuery.bool.should = combinedShould
+    osQuery.bool.minimum_should_match = 1
   }
   if (!isEmpty(combinedMustNot)) {
     osQuery.bool.must_not = combinedMustNot

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -28,6 +28,7 @@ const UNPREFIXED_FIELDS = [
   'id',
   'collection',
   'geometry',
+  'bbox'
 ]
 
 let collectionToIndexMapping = null

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -198,12 +198,7 @@ function buildFilterExtQuery(filter) {
     '>=': 'gte'
   }
 
-  const unprefixed = ['id', 'collection', 'geometry', 'bbox']
-
-  let cql2Field = filter.args[0].property
-  if (!unprefixed.includes(cql2Field)) {
-    cql2Field = `properties.${cql2Field}`
-  }
+  const cql2Field = filter.args[0].property
 
   let cql2Value = filter.args[1]
   if (typeof cql2Value === 'object' && cql2Value.timestamp) {

--- a/tests/fixtures/stac/collection-with-incorrect-queryables.json
+++ b/tests/fixtures/stac/collection-with-incorrect-queryables.json
@@ -1,0 +1,41 @@
+{
+    "id": "landsat-8-l1-incorrect-queryables",
+    "type": "Collection",
+    "stac_version": "1.0.0",
+    "description": "Landat-8 L1 Collection-1 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
+    "links": [],
+    "stac_extensions": [],
+    "title": "Landsat-8 L1 Collection-1",
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180,
+                    -90,
+                    180,
+                    90
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2013-06-01T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "queryables": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "",
+        "type": "object",
+        "title": "",
+        "properties": {
+            "eo:cloud_cover": {
+                "$ref": "https://stac-extensions.github.io/eo/v1.0.0/schema.json#/definitions/fields/properties/eo:cloud_cover"
+            }
+        },
+        "additionalProperties": false
+    }
+}

--- a/tests/system/test-api-get-aggregate.js
+++ b/tests/system/test-api-get-aggregate.js
@@ -478,7 +478,7 @@ test('GET /aggregate with aggregations and filter params', async (t) => {
             op: '>',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               0.54
             ]

--- a/tests/system/test-api-get-conformance.js
+++ b/tests/system/test-api-get-conformance.js
@@ -13,7 +13,7 @@ test.after.always(async (t) => {
 
 test('GET /conformance returns the expected conformsTo list', async (t) => {
   const response = await t.context.api.client.get('conformance')
-  t.is(response.conformsTo.length, 19)
+  t.is(response.conformsTo.length, 21)
 })
 
 test('GET /conformance has a content type of "application/json', async (t) => {

--- a/tests/system/test-api-get-conformance.js
+++ b/tests/system/test-api-get-conformance.js
@@ -13,7 +13,7 @@ test.after.always(async (t) => {
 
 test('GET /conformance returns the expected conformsTo list', async (t) => {
   const response = await t.context.api.client.get('conformance')
-  t.is(response.conformsTo.length, 15)
+  t.is(response.conformsTo.length, 19)
 })
 
 test('GET /conformance has a content type of "application/json', async (t) => {

--- a/tests/system/test-api-search-get.js
+++ b/tests/system/test-api-search-get.js
@@ -133,7 +133,7 @@ test('/search filter, query, and item search in single request', async (t) => {
         op: '>',
         args: [
           {
-            property: 'properties.eo:cloud_cover'
+            property: 'eo:cloud_cover'
           },
           0.54
         ]

--- a/tests/system/test-api-search-get.js
+++ b/tests/system/test-api-search-get.js
@@ -133,7 +133,7 @@ test('/search filter, query, and item search in single request', async (t) => {
         op: '>',
         args: [
           {
-            property: 'eo:cloud_cover'
+            property: 'properties.eo:cloud_cover'
           },
           0.54
         ]

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -659,7 +659,7 @@ test('/search filter extension - comparison operators', async (t) => {
         op: '=',
         args: [
           {
-            property: 'platform'
+            property: 'properties.platform'
           },
           'landsat-8'
         ]
@@ -675,7 +675,7 @@ test('/search filter extension - comparison operators', async (t) => {
         op: '<>',
         args: [
           {
-            property: 'platform'
+            property: 'properties.platform'
           },
           'landsat-8'
         ]
@@ -691,7 +691,7 @@ test('/search filter extension - comparison operators', async (t) => {
         op: 'isNull',
         args: [
           {
-            property: 'landsat:product_id'
+            property: 'properties.landsat:product_id'
           }
         ]
       }
@@ -705,7 +705,7 @@ test('/search filter extension - comparison operators', async (t) => {
         op: 'isNull',
         args: [
           {
-            property: 'gsd'
+            property: 'properties.gsd'
           }
         ]
       }
@@ -720,7 +720,7 @@ test('/search filter extension - comparison operators', async (t) => {
         op: '<',
         args: [
           {
-            property: 'eo:cloud_cover'
+            property: 'properties.eo:cloud_cover'
           },
           8.0
         ]
@@ -736,7 +736,7 @@ test('/search filter extension - comparison operators', async (t) => {
         op: '<=',
         args: [
           {
-            property: 'eo:cloud_cover'
+            property: 'properties.eo:cloud_cover'
           },
           0.54
         ]
@@ -752,7 +752,7 @@ test('/search filter extension - comparison operators', async (t) => {
         op: '>',
         args: [
           {
-            property: 'eo:cloud_cover'
+            property: 'properties.eo:cloud_cover'
           },
           0.54
         ]
@@ -768,7 +768,7 @@ test('/search filter extension - comparison operators', async (t) => {
         op: '>=',
         args: [
           {
-            property: 'eo:cloud_cover'
+            property: 'properties.eo:cloud_cover'
           },
           0.54
         ]
@@ -791,7 +791,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '>',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               0.54
             ]
@@ -800,7 +800,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '<',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               8.0
             ]
@@ -820,7 +820,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '>=',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               0.54
             ]
@@ -829,7 +829,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '<',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               8.0
             ]
@@ -850,7 +850,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '>',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               0.54
             ]
@@ -859,7 +859,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '<',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               8.0
             ]
@@ -880,7 +880,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '>',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               0.54
             ]
@@ -900,7 +900,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '>',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               0.54
             ]
@@ -909,7 +909,7 @@ test('/search filter extension - logical operators', async (t) => {
             op: '<',
             args: [
               {
-                property: 'eo:cloud_cover'
+                property: 'properties.eo:cloud_cover'
               },
               8.0
             ]
@@ -922,13 +922,32 @@ test('/search filter extension - logical operators', async (t) => {
 })
 
 test('/search filter extension - handles timestamps', async (t) => {
-  const response = await t.context.api.client.post('search', {
+  let response = null
+
+  response = await t.context.api.client.post('search', {
     json: {
       filter: {
         op: '>',
         args: [
           {
-            property: 'datetime'
+            property: 'properties.datetime'
+          },
+          {
+            timestamp: '2015-02-20T00:00:00Z'
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 1)
+
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: '>',
+        args: [
+          {
+            property: 'properties.datetime'
           },
           '2015-02-20T00:00:00Z'
         ]
@@ -951,7 +970,7 @@ test('/search filter, query, and item search in single request', async (t) => {
         op: '>',
         args: [
           {
-            property: 'eo:cloud_cover'
+            property: 'properties.eo:cloud_cover'
           },
           0.54
         ]

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -1040,22 +1040,20 @@ test('/search - filter extension - with top level field filtering', async (t) =>
 })
 
 test('/search - filter extension - failure with incorrect filter-lang', async (t) => {
-  const error = await t.throwsAsync(
-    t.context.api.client.post('search', {
-      json: {
-        'filter-lang': 'not-cql2-json',
-        filter: {
-          op: '>',
-          args: [
-            {
-              property: 'eo:cloud_cover'
-            },
-            0.54
-          ]
-        }
+  const error = await t.throwsAsync(async () => t.context.api.client.post('search', {
+    json: {
+      'filter-lang': 'not-cql2-json',
+      filter: {
+        op: '>',
+        args: [
+          {
+            property: 'eo:cloud_cover'
+          },
+          0.54
+        ]
       }
-    })
-  )
+    }
+  }))
   t.is(error.response.statusCode, 400)
   t.is(error.response.body.code, 'BadRequest')
   t.regex(error.response.body.description,
@@ -1063,22 +1061,20 @@ test('/search - filter extension - failure with incorrect filter-lang', async (t
 })
 
 test('/search - filter extension - failure with incorrect filter-crs', async (t) => {
-  const error = await t.throwsAsync(
-    t.context.api.client.post('search', {
-      json: {
-        'filter-crs': 'not-crs84-url',
-        filter: {
-          op: '>',
-          args: [
-            {
-              property: 'eo:cloud_cover'
-            },
-            0.54
-          ]
-        }
+  const error = await t.throwsAsync(async () => t.context.api.client.post('search', {
+    json: {
+      'filter-crs': 'not-crs84-url',
+      filter: {
+        op: '>',
+        args: [
+          {
+            property: 'eo:cloud_cover'
+          },
+          0.54
+        ]
       }
-    })
-  )
+    }
+  }))
   t.is(error.response.statusCode, 400)
   t.is(error.response.body.code, 'BadRequest')
   t.regex(error.response.body.description,

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -973,6 +973,32 @@ test('/search - filter, query, and item search in single request', async (t) => 
   t.is(response.features.length, 1)
 })
 
+test('/search - filter extension - with top level field filtering', async (t) => {
+  const response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: 'and',
+        args: [
+          {
+            op: '=',
+            args: [
+              {
+                property: 'properties.eo:cloud_cover'
+              },
+              0.54
+            ]
+          },
+          {
+            op: '=',
+            args: [{ property: 'collection' }, 'collection2']
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 1)
+})
+
 test('/search - filter extension - failure with incorrect filter-lang', async (t) => {
   const error = await t.throwsAsync(
     t.context.api.client.post('search', {

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -643,3 +643,336 @@ test('/search Query Extension', async (t) => {
   })
   t.is(response.features.length, 0)
 })
+
+test('/search Filter Extension - Null filter', async (t) => {
+  // 3 items, 2 with platform landsat-8, 1 with platform2
+
+  let response = null
+
+  response = await t.context.api.client.post('search', {
+    json: {}
+  })
+  t.is(response.features.length, 3)
+})
+
+test.only('/search Filter Extension - Comparison Operators', async (t) => {
+  // 3 items, 2 with platform landsat-8, 1 with platform2
+
+  let response = null
+
+  // equal
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: '=',
+        args: [
+          {
+            property: 'platform'
+          },
+          'landsat-8'
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 2)
+
+  // not equal
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: '<>',
+        args: [
+          {
+            property: 'platform'
+          },
+          'landsat-8'
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 1)
+
+  // is null
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: 'isNull',
+        args: [
+          {
+            property: 'landsat:product_id'
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 3)
+
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: 'isNull',
+        args: [
+          {
+            property: 'gsd'
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 2)
+
+  // less than
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: '<',
+        args: [
+          {
+            property: 'eo:cloud_cover'
+          },
+          8.0
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 2)
+
+  // less than or equal
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: '<=',
+        args: [
+          {
+            property: 'eo:cloud_cover'
+          },
+          0.54
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 2)
+
+  // greater than
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: '>',
+        args: [
+          {
+            property: 'eo:cloud_cover'
+          },
+          0.54
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 1)
+
+  // greater than or equal
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: '>=',
+        args: [
+          {
+            property: 'eo:cloud_cover'
+          },
+          0.54
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 3)
+})
+
+test('/search Filter Extension - Logical Operators', async (t) => {
+  // 3 items, 2 with platform landsat-8, 1 with platform2
+
+  let response = null
+
+  // and
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: 'and',
+        args: [
+          {
+            op: '>',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              0.54
+            ]
+          },
+          {
+            op: '<',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              8.0
+            ]
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 0)
+
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: 'and',
+        args: [
+          {
+            op: '>=',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              0.54
+            ]
+          },
+          {
+            op: '<',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              8.0
+            ]
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 2)
+
+  // or
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: 'or',
+        args: [
+          {
+            op: '>',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              0.54
+            ]
+          },
+          {
+            op: '<',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              8.0
+            ]
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 3)
+
+  // not
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: 'not',
+        args: [
+          {
+            op: '>',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              0.54
+            ]
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 2)
+
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: 'not',
+        args: [
+          {
+            op: '>',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              0.54
+            ]
+          },
+          {
+            op: '<',
+            args: [
+              {
+                property: 'eo:cloud_cover'
+              },
+              8.0
+            ]
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 0)
+})
+
+test('/search Filter Extension - Timestamps', async (t) => {
+  // 3 items, 2 with platform landsat-8, 1 with platform2
+
+  let response = null
+
+  response = await t.context.api.client.post('search', {
+    json: {
+      filter: {
+        op: '>',
+        args: [
+          {
+            property: 'datetime'
+          },
+          '2015-02-20T00:00:00Z'
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 1)
+})
+
+test('/search Combined Item Search and Filter and Query Extensions', async (t) => {
+  let response = null
+
+  response = await t.context.api.client.post('search', {
+    json: {
+      collections: ['landsat-8-l1'],
+      query: {
+        'view:sun_elevation': {
+          gt: 20
+        }
+      },
+      filter: {
+        op: '>',
+        args: [
+          {
+            property: 'eo:cloud_cover'
+          },
+          0.54
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 1)
+})

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -655,7 +655,7 @@ test('/search Filter Extension - Null filter', async (t) => {
   t.is(response.features.length, 3)
 })
 
-test.only('/search Filter Extension - Comparison Operators', async (t) => {
+test('/search Filter Extension - Comparison Operators', async (t) => {
   // 3 items, 2 with platform landsat-8, 1 with platform2
 
   let response = null

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -652,7 +652,7 @@ test('/search - filter extension - comparison operators', async (t) => {
         op: '=',
         args: [
           {
-            property: 'properties.platform'
+            property: 'platform'
           },
           'landsat-8'
         ]
@@ -668,7 +668,7 @@ test('/search - filter extension - comparison operators', async (t) => {
         op: '<>',
         args: [
           {
-            property: 'properties.platform'
+            property: 'platform'
           },
           'landsat-8'
         ]
@@ -684,7 +684,7 @@ test('/search - filter extension - comparison operators', async (t) => {
         op: 'isNull',
         args: [
           {
-            property: 'properties.landsat:product_id'
+            property: 'landsat:product_id'
           }
         ]
       }
@@ -698,7 +698,7 @@ test('/search - filter extension - comparison operators', async (t) => {
         op: 'isNull',
         args: [
           {
-            property: 'properties.gsd'
+            property: 'gsd'
           }
         ]
       }
@@ -713,7 +713,7 @@ test('/search - filter extension - comparison operators', async (t) => {
         op: '<',
         args: [
           {
-            property: 'properties.eo:cloud_cover'
+            property: 'eo:cloud_cover'
           },
           8.0
         ]
@@ -729,7 +729,7 @@ test('/search - filter extension - comparison operators', async (t) => {
         op: '<=',
         args: [
           {
-            property: 'properties.eo:cloud_cover'
+            property: 'eo:cloud_cover'
           },
           0.54
         ]
@@ -745,7 +745,7 @@ test('/search - filter extension - comparison operators', async (t) => {
         op: '>',
         args: [
           {
-            property: 'properties.eo:cloud_cover'
+            property: 'eo:cloud_cover'
           },
           0.54
         ]
@@ -761,7 +761,7 @@ test('/search - filter extension - comparison operators', async (t) => {
         op: '>=',
         args: [
           {
-            property: 'properties.eo:cloud_cover'
+            property: 'eo:cloud_cover'
           },
           0.54
         ]
@@ -783,7 +783,7 @@ test('/search - filter extension - AND logical operator', async (t) => {
             op: '>',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               0.54
             ]
@@ -792,7 +792,7 @@ test('/search - filter extension - AND logical operator', async (t) => {
             op: '<',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               8.0
             ]
@@ -812,7 +812,7 @@ test('/search - filter extension - AND logical operator', async (t) => {
             op: '>=',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               0.54
             ]
@@ -821,7 +821,7 @@ test('/search - filter extension - AND logical operator', async (t) => {
             op: '<',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               8.0
             ]
@@ -845,7 +845,7 @@ test('/search - filter extension - OR logical operator', async (t) => {
             op: '>',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               0.54
             ]
@@ -854,7 +854,7 @@ test('/search - filter extension - OR logical operator', async (t) => {
             op: '<',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               8.0
             ]
@@ -880,7 +880,7 @@ test('/search - filter extension - OR logical operator', async (t) => {
             op: '>',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               10.0
             ]
@@ -889,7 +889,7 @@ test('/search - filter extension - OR logical operator', async (t) => {
             op: '<',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               0.5
             ]
@@ -913,7 +913,7 @@ test('/search - filter extension - NOT logical operator', async (t) => {
             op: '>',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               0.54
             ]
@@ -933,7 +933,7 @@ test('/search - filter extension - NOT logical operator', async (t) => {
             op: '>',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               0.54
             ]
@@ -942,7 +942,7 @@ test('/search - filter extension - NOT logical operator', async (t) => {
             op: '<',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               8.0
             ]
@@ -963,7 +963,7 @@ test('/search - filter extension - handles timestamps', async (t) => {
         op: '>',
         args: [
           {
-            property: 'properties.datetime'
+            property: 'datetime'
           },
           {
             timestamp: '2015-02-20T00:00:00Z'
@@ -980,7 +980,7 @@ test('/search - filter extension - handles timestamps', async (t) => {
         op: '>',
         args: [
           {
-            property: 'properties.datetime'
+            property: 'datetime'
           },
           '2015-02-20T00:00:00Z'
         ]
@@ -1003,7 +1003,7 @@ test('/search - filter, query, and item search in single request', async (t) => 
         op: '>',
         args: [
           {
-            property: 'properties.eo:cloud_cover'
+            property: 'eo:cloud_cover'
           },
           0.54
         ]
@@ -1023,7 +1023,7 @@ test('/search - filter extension - with top level field filtering', async (t) =>
             op: '=',
             args: [
               {
-                property: 'properties.eo:cloud_cover'
+                property: 'eo:cloud_cover'
               },
               0.54
             ]
@@ -1048,7 +1048,7 @@ test('/search - filter extension - failure with incorrect filter-lang', async (t
           op: '>',
           args: [
             {
-              property: 'properties.eo:cloud_cover'
+              property: 'eo:cloud_cover'
             },
             0.54
           ]
@@ -1071,7 +1071,7 @@ test('/search - filter extension - failure with incorrect filter-crs', async (t)
           op: '>',
           args: [
             {
-              property: 'properties.eo:cloud_cover'
+              property: 'eo:cloud_cover'
             },
             0.54
           ]

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -642,13 +642,6 @@ test('/search query extension', async (t) => {
   t.is(response.features.length, 0)
 })
 
-test('/search filter extension - empty filter', async (t) => {
-  const response = await t.context.api.client.post('search', {
-    json: {}
-  })
-  t.is(response.features.length, 3)
-})
-
 test('/search filter extension - comparison operators', async (t) => {
   let response = null
 

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -833,7 +833,7 @@ test('/search - filter extension - AND logical operator', async (t) => {
   t.is(response.features.length, 2)
 })
 
-test.only('/search - filter extension - OR logical operator', async (t) => {
+test('/search - filter extension - OR logical operator', async (t) => {
   let response = null
 
   response = await t.context.api.client.post('search', {
@@ -868,8 +868,8 @@ test.only('/search - filter extension - OR logical operator', async (t) => {
   // Test case for an OpenSearch query with `filter` and `should` keys directly under a
   // `bool` key. In this case, OpenSearch uses a default `minimum_should_match` value of
   // 0, meaning that no matches in the specified `or` list are required. We test here that
-  // `minimum_should_match` is set to 1, therefore requiring at least one of the
-  // conditions in the `or` list to be met.
+  // `minimum_should_match` has been set to 1, with the effect of requiring at least one
+  // of the conditions in the `or` list to be met.
   response = await t.context.api.client.post('search', {
     json: {
       collections: ['landsat-8-l1'],

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -537,7 +537,7 @@ test('/search preserve bbox in prev and next links', async (t) => {
   t.deepEqual(linkRel(response, 'next').body.bbox, bbox)
 })
 
-test('/search query extension', async (t) => {
+test('/search - query extension', async (t) => {
   let response = null
 
   response = await t.context.api.client.post('search', {
@@ -642,7 +642,7 @@ test('/search query extension', async (t) => {
   t.is(response.features.length, 0)
 })
 
-test('/search filter extension - comparison operators', async (t) => {
+test('/search - filter extension - comparison operators', async (t) => {
   let response = null
 
   // equal
@@ -771,7 +771,7 @@ test('/search filter extension - comparison operators', async (t) => {
   t.is(response.features.length, 3)
 })
 
-test('/search filter extension - logical operators', async (t) => {
+test('/search - filter extension - logical operators', async (t) => {
   let response = null
 
   // and
@@ -914,7 +914,7 @@ test('/search filter extension - logical operators', async (t) => {
   t.is(response.features.length, 0)
 })
 
-test('/search filter extension - handles timestamps', async (t) => {
+test('/search - filter extension - handles timestamps', async (t) => {
   let response = null
 
   response = await t.context.api.client.post('search', {
@@ -950,7 +950,7 @@ test('/search filter extension - handles timestamps', async (t) => {
   t.is(response.features.length, 1)
 })
 
-test('/search filter, query, and item search in single request', async (t) => {
+test('/search - filter, query, and item search in single request', async (t) => {
   const response = await t.context.api.client.post('search', {
     json: {
       collections: ['landsat-8-l1'],
@@ -971,4 +971,50 @@ test('/search filter, query, and item search in single request', async (t) => {
     }
   })
   t.is(response.features.length, 1)
+})
+
+test('/search - filter extension - failure with incorrect filter-lang', async (t) => {
+  const error = await t.throwsAsync(
+    t.context.api.client.post('search', {
+      json: {
+        'filter-lang': 'not-cql2-json',
+        filter: {
+          op: '>',
+          args: [
+            {
+              property: 'properties.eo:cloud_cover'
+            },
+            0.54
+          ]
+        }
+      }
+    })
+  )
+  t.is(error.response.statusCode, 400)
+  t.is(error.response.body.code, 'BadRequest')
+  t.regex(error.response.body.description,
+    /.*filter-lang must be "cql2-json".*/)
+})
+
+test('/search - filter extension - failure with incorrect filter-crs', async (t) => {
+  const error = await t.throwsAsync(
+    t.context.api.client.post('search', {
+      json: {
+        'filter-crs': 'not-crs84-url',
+        filter: {
+          op: '>',
+          args: [
+            {
+              property: 'properties.eo:cloud_cover'
+            },
+            0.54
+          ]
+        }
+      }
+    })
+  )
+  t.is(error.response.statusCode, 400)
+  t.is(error.response.body.code, 'BadRequest')
+  t.regex(error.response.body.description,
+    /.*filter-crs must be "http:\/\/www.opengis.net\/def\/crs\/OGC\/1.3\/CRS84".*/)
 })

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -771,10 +771,9 @@ test('/search - filter extension - comparison operators', async (t) => {
   t.is(response.features.length, 3)
 })
 
-test('/search - filter extension - logical operators', async (t) => {
+test('/search - filter extension - AND logical operator', async (t) => {
   let response = null
 
-  // and
   response = await t.context.api.client.post('search', {
     json: {
       filter: {
@@ -832,8 +831,11 @@ test('/search - filter extension - logical operators', async (t) => {
     }
   })
   t.is(response.features.length, 2)
+})
 
-  // or
+test.only('/search - filter extension - OR logical operator', async (t) => {
+  let response = null
+
   response = await t.context.api.client.post('search', {
     json: {
       filter: {
@@ -863,7 +865,45 @@ test('/search - filter extension - logical operators', async (t) => {
   })
   t.is(response.features.length, 3)
 
-  // not
+  // Test case for an OpenSearch query with `filter` and `should` keys directly under a
+  // `bool` key. In this case, OpenSearch uses a default `minimum_should_match` value of
+  // 0, meaning that no matches in the specified `or` list are required. We test here that
+  // `minimum_should_match` is set to 1, therefore requiring at least one of the
+  // conditions in the `or` list to be met.
+  response = await t.context.api.client.post('search', {
+    json: {
+      collections: ['landsat-8-l1'],
+      filter: {
+        op: 'or',
+        args: [
+          {
+            op: '>',
+            args: [
+              {
+                property: 'properties.eo:cloud_cover'
+              },
+              10.0
+            ]
+          },
+          {
+            op: '<',
+            args: [
+              {
+                property: 'properties.eo:cloud_cover'
+              },
+              0.5
+            ]
+          }
+        ]
+      }
+    }
+  })
+  t.is(response.features.length, 0)
+})
+
+test('/search - filter extension - NOT logical operator', async (t) => {
+  let response = null
+
   response = await t.context.api.client.post('search', {
     json: {
       filter: {

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -537,10 +537,8 @@ test('/search preserve bbox in prev and next links', async (t) => {
   t.deepEqual(linkRel(response, 'next').body.bbox, bbox)
 })
 
-test('/search Query Extension', async (t) => {
+test('/search query extension', async (t) => {
   let response = null
-
-  // 3 items, 2 with platform landsat-8, 1 with platform2
 
   response = await t.context.api.client.post('search', {
     json: {}
@@ -644,20 +642,14 @@ test('/search Query Extension', async (t) => {
   t.is(response.features.length, 0)
 })
 
-test('/search Filter Extension - Null filter', async (t) => {
-  // 3 items, 2 with platform landsat-8, 1 with platform2
-
-  let response = null
-
-  response = await t.context.api.client.post('search', {
+test('/search filter extension - empty filter', async (t) => {
+  const response = await t.context.api.client.post('search', {
     json: {}
   })
   t.is(response.features.length, 3)
 })
 
-test('/search Filter Extension - Comparison Operators', async (t) => {
-  // 3 items, 2 with platform landsat-8, 1 with platform2
-
+test('/search filter extension - comparison operators', async (t) => {
   let response = null
 
   // equal
@@ -786,9 +778,7 @@ test('/search Filter Extension - Comparison Operators', async (t) => {
   t.is(response.features.length, 3)
 })
 
-test('/search Filter Extension - Logical Operators', async (t) => {
-  // 3 items, 2 with platform landsat-8, 1 with platform2
-
+test('/search filter extension - logical operators', async (t) => {
   let response = null
 
   // and
@@ -931,12 +921,8 @@ test('/search Filter Extension - Logical Operators', async (t) => {
   t.is(response.features.length, 0)
 })
 
-test('/search Filter Extension - Timestamps', async (t) => {
-  // 3 items, 2 with platform landsat-8, 1 with platform2
-
-  let response = null
-
-  response = await t.context.api.client.post('search', {
+test('/search filter extension - handles timestamps', async (t) => {
+  const response = await t.context.api.client.post('search', {
     json: {
       filter: {
         op: '>',
@@ -952,10 +938,8 @@ test('/search Filter Extension - Timestamps', async (t) => {
   t.is(response.features.length, 1)
 })
 
-test('/search Combined Item Search and Filter and Query Extensions', async (t) => {
-  let response = null
-
-  response = await t.context.api.client.post('search', {
+test('/search filter, query, and item search in single request', async (t) => {
+  const response = await t.context.api.client.post('search', {
     json: {
       collections: ['landsat-8-l1'],
       query: {


### PR DESCRIPTION
**Related Issue(s):** 

- #72. Note that this issue calls for both Basic CQL2 and Basic Spatial Operators, but this MR only implements Basic CQL2.


**Proposed Changes:**

Minimum implementation of the [filter extension](https://github.com/stac-api-extensions/filter).
- Basic CQL2
- CQL2 JSON (no CQL Text)
- Available to the `/search` (GET and POST), `/collections/{collectionId}/items` (GET), and `/aggregate` (GET) endpoints

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
