### PR TITLE
remove stac_version and stac_extensions from itemcollection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.10.0] - TBD
+
+### Fixed
+
+- Removed inapplicable `stac_version` and `stac_extensions` fields from ItemCollection
+
 ## [3.9.0] - 2025-01-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "stac-server",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stac-server",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "license": "MIT",
       "dependencies": {
+        "18": "^0.0.0",
         "@aws-sdk/client-s3": "^3.575.0",
         "@aws-sdk/client-secrets-manager": "^3.575.0",
         "@aws-sdk/client-sns": "^3.575.0",
@@ -14294,6 +14295,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+    },
+    "node_modules/18": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/18/-/18-0.0.0.tgz",
+      "integrity": "sha512-2SPMA/ciHy16yY4uVXDrW8q7nLwb2F2Vrt8Qz5OiVo9cyC8Wo8/rwC2hDzbqlTXhIwzt2Y4yJRLem6XMNbT/3A==",
+      "license": "ISC"
     },
     "node_modules/2-thenable": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "stac-server",
   "description": "A STAC API running on stac-server",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "repository": "https://github.com/stac-utils/stac-server",
   "author": "Alireza Jazayeri, Matthew Hanson, Sean Harkins, Phil Varner",
   "license": "MIT",
@@ -62,6 +62,7 @@
     "url": "https://github.com/stac-utils/stac-server/issues"
   },
   "dependencies": {
+    "18": "^0.0.0",
     "@aws-sdk/client-s3": "^3.575.0",
     "@aws-sdk/client-secrets-manager": "^3.575.0",
     "@aws-sdk/client-sns": "^3.575.0",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -540,8 +540,6 @@ const wrapResponseInFeatureCollection = function (
 ) {
   return {
     type: 'FeatureCollection',
-    stac_version: process.env['STAC_VERSION'] || '1.0.0',
-    stac_extensions: [],
     context,
     numberMatched: context.matched,
     numberReturned: context.returned,


### PR DESCRIPTION
**Related Issue(s):** 

- #832 


**Proposed Changes:**

1. remove stac_version and stac_extensions from itemcollection, as they are not fields for this entity

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
