### PR TITLE
change semantics of ENABLE_COLLECTIONS_AUTHX to fail closed and allow * for all collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2024-04-21
+
+### Changed
+
+- **breaking** Collections Auth features (ENABLE_COLLECTIONS_AUTHX) now fails closed
+  rather than open. If `_collections` is not specified or is empty, caller has no
+  access to collections. Also, adds a special collection name `*` that means access
+  to all collections is granted.
+
 ## [4.0.0] - 2025-04-07
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,11 @@ The endpoints this applies to are:
 The five endpoints of the Transaction Extension do not use this parameter, as there are
 other authorization considerations for these, that are left as future work.
 
+If this behavior is enabled and a `_collections` parameter is not passed or is passed
+with an empty string or empty list, the caller will not have access to any collections.
+When `*` is included in the list of collections (ideally as the only value), the caller
+will have access to all collections.
+
 ## Ingesting Data
 
 STAC Collections and Items are ingested by the `ingest` Lambda function, however this Lambda is not invoked directly by a user, it consumes records from the `stac-server-<stage>-queue` SQS. To add STAC Items or Collections to the queue, publish them to the SNS Topic `stac-server-<stage>-ingest`.

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -315,6 +315,11 @@ const extractFields = function (params) {
   return fieldRules
 }
 
+/**
+ * Parse a string or array of IDs into an array of strings or undefined.
+ * @param {string | string[] | undefined} ids - The IDs parameter to parse
+ * @returns {string[] | undefined} Parsed array of ID strings or undefined
+ */
 const parseIds = function (ids) {
   let idsRules
   if (ids) {
@@ -337,12 +342,26 @@ const extractIds = function (params) {
 
 const extractAllowedCollectionIds = function (params) {
   return process.env['ENABLE_COLLECTIONS_AUTHX'] === 'true'
-    ? parseIds(params._collections)
+    ? parseIds(params._collections) || []
     : undefined
 }
 
 const extractCollectionIds = function (params) {
   return parseIds(params.collections)
+}
+
+const filterAllowedCollectionIds = function (allowedCollectionIds, specifiedCollectionIds) {
+  return (
+    Array.isArray(allowedCollectionIds) && !allowedCollectionIds.includes('*')
+  ) ? allowedCollectionIds.filter(
+      (x) => !specifiedCollectionIds || specifiedCollectionIds.includes(x)
+    ) : specifiedCollectionIds
+}
+
+const isCollectionIdAllowed = function (allowedCollectionIds, collectionId) {
+  return !Array.isArray(allowedCollectionIds)
+          || allowedCollectionIds.includes(collectionId)
+          || allowedCollectionIds.includes('*')
 }
 
 export const parsePath = function (inpath) {
@@ -577,9 +596,7 @@ const searchItems = async function (collectionId, queryParameters, backend, endp
   const ids = extractIds(queryParameters)
   const allowedCollectionIds = extractAllowedCollectionIds(queryParameters)
   const specifiedCollectionIds = extractCollectionIds(queryParameters)
-  const collections = allowedCollectionIds ? allowedCollectionIds.filter(
-    (x) => !specifiedCollectionIds || specifiedCollectionIds.includes(x)
-  ) : specifiedCollectionIds
+  const collections = filterAllowedCollectionIds(allowedCollectionIds, specifiedCollectionIds)
   const limit = extractLimit(queryParameters) || 10
   const page = extractPage(queryParameters)
 
@@ -715,9 +732,28 @@ const aggregate = async function (
   const ids = extractIds(queryParameters)
   const allowedCollectionIds = extractAllowedCollectionIds(queryParameters)
   const specifiedCollectionIds = extractCollectionIds(queryParameters)
-  const collections = allowedCollectionIds ? allowedCollectionIds.filter(
-    (x) => !specifiedCollectionIds || specifiedCollectionIds.includes(x)
-  ) : specifiedCollectionIds
+  const collections = filterAllowedCollectionIds(allowedCollectionIds, specifiedCollectionIds)
+
+  if (Array.isArray(collections) && !collections.length) {
+    if (collectionId) {
+      return new NotFoundError()
+    }
+
+    return {
+      aggregations: [],
+      links: [
+        {
+          rel: 'self',
+          type: 'application/json',
+          href: `${endpoint}/aggregate`
+        },
+        {
+          rel: 'root',
+          type: 'application/json',
+          href: `${endpoint}`
+        }]
+    }
+  }
 
   const searchParams = pickBy({
     datetime,
@@ -991,7 +1027,7 @@ const validateAdditionalProperties = (queryables) => {
 
 const getCollectionQueryables = async (collectionId, backend, endpoint, queryParameters) => {
   const allowedCollectionIds = extractAllowedCollectionIds(queryParameters)
-  if (allowedCollectionIds && !allowedCollectionIds.includes(collectionId)) {
+  if (!isCollectionIdAllowed(allowedCollectionIds, collectionId)) {
     return new NotFoundError()
   }
 
@@ -1008,8 +1044,7 @@ const getCollectionQueryables = async (collectionId, backend, endpoint, queryPar
 }
 
 const getCollectionAggregations = async (collectionId, backend, endpoint, queryParameters) => {
-  const allowedCollectionIds = extractAllowedCollectionIds(queryParameters)
-  if (allowedCollectionIds && !allowedCollectionIds.includes(collectionId)) {
+  if (!isCollectionIdAllowed(extractAllowedCollectionIds(queryParameters), collectionId)) {
     return new NotFoundError()
   }
 
@@ -1155,7 +1190,7 @@ const getCollections = async function (backend, endpoint, queryParameters) {
 
   const allowedCollectionIds = extractAllowedCollectionIds(queryParameters)
   const collections = collectionsOrError.filter(
-    (c) => !allowedCollectionIds || allowedCollectionIds.includes(c.id)
+    (c) => isCollectionIdAllowed(allowedCollectionIds, c.id)
   )
 
   for (const collection of collections) {
@@ -1194,8 +1229,7 @@ const getCollections = async function (backend, endpoint, queryParameters) {
 }
 
 const getCollection = async function (collectionId, backend, endpoint, queryParameters) {
-  const allowedCollectionIds = extractAllowedCollectionIds(queryParameters)
-  if (allowedCollectionIds && !allowedCollectionIds.includes(collectionId)) {
+  if (!isCollectionIdAllowed(extractAllowedCollectionIds(queryParameters), collectionId)) {
     return new NotFoundError()
   }
 
@@ -1224,8 +1258,7 @@ const createCollection = async function (collection, backend) {
 }
 
 const getItem = async function (collectionId, itemId, backend, endpoint, queryParameters) {
-  const allowedCollectionIds = extractAllowedCollectionIds(queryParameters)
-  if (allowedCollectionIds && !allowedCollectionIds.includes(collectionId)) {
+  if (!isCollectionIdAllowed(extractAllowedCollectionIds(queryParameters), collectionId)) {
     return new NotFoundError()
   }
 
@@ -1279,8 +1312,7 @@ const deleteItem = async function (collectionId, itemId, backend) {
 }
 
 const getItemThumbnail = async function (collectionId, itemId, backend, queryParameters) {
-  const allowedCollectionIds = extractAllowedCollectionIds(queryParameters)
-  if (allowedCollectionIds && !allowedCollectionIds.includes(collectionId)) {
+  if (!isCollectionIdAllowed(extractAllowedCollectionIds(queryParameters), collectionId)) {
     return new NotFoundError()
   }
 

--- a/tests/system/test-api-collection-items-get.js
+++ b/tests/system/test-api-collection-items-get.js
@@ -58,6 +58,10 @@ test.before(async (t) => {
   })
 })
 
+test.beforeEach(async (_) => {
+  delete process.env['ENABLE_COLLECTIONS_AUTHX']
+})
+
 test.after.always(async (t) => {
   if (t.context.api) await t.context.api.close()
 })
@@ -98,8 +102,22 @@ test('GET /collections/:collectionId/items with restriction returns filtered col
 
   const path = `collections/${collectionId}/items`
 
+  // _collections undefined
   t.is((await t.context.api.client.get(path,
-    { resolveBodyOnly: false })).statusCode, 200)
+    { resolveBodyOnly: false, throwHttpErrors: false })).statusCode, 404)
+
+  // _collections empty
+  t.is((await t.context.api.client.get(path,
+    { resolveBodyOnly: false,
+      throwHttpErrors: false,
+      searchParams: { _collections: '' },
+    })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    {
+      resolveBodyOnly: false,
+      searchParams: { _collections: '*' }
+    })).statusCode, 200)
 
   t.is((await t.context.api.client.get(path,
     {

--- a/tests/system/test-api-get-collection-aggregations.js
+++ b/tests/system/test-api-get-collection-aggregations.js
@@ -15,6 +15,10 @@ test.before(async (t) => {
   t.context.collectionId = randomId('collection')
 })
 
+test.beforeEach(async (_) => {
+  delete process.env['ENABLE_COLLECTIONS_AUTHX']
+})
+
 test.after.always(async (t) => {
   if (t.context.api) await t.context.api.close()
 })
@@ -138,7 +142,20 @@ test('GET /collections/:collectionId/aggregations with restriction returns filte
   const path = `collections/${collectionId}/aggregations`
 
   t.is((await t.context.api.client.get(path,
-    { resolveBodyOnly: false })).statusCode, 200)
+    { resolveBodyOnly: false, throwHttpErrors: false })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    {
+      resolveBodyOnly: false,
+      throwHttpErrors: false,
+      searchParams: { _collections: '' }
+    })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    {
+      resolveBodyOnly: false,
+      searchParams: { _collections: '*' }
+    })).statusCode, 200)
 
   t.is((await t.context.api.client.get(path,
     {

--- a/tests/system/test-api-get-collection-queryables.js
+++ b/tests/system/test-api-get-collection-queryables.js
@@ -15,6 +15,10 @@ test.before(async (t) => {
   t.context.collectionId = randomId('collection')
 })
 
+test.beforeEach(async (_) => {
+  delete process.env['ENABLE_COLLECTIONS_AUTHX']
+})
+
 test.after.always(async (t) => {
   if (t.context.api) await t.context.api.close()
 })
@@ -120,7 +124,19 @@ test('GET /collections/:collectionId/queryables with restriction returns filtere
   const path = `collections/${collectionId}/queryables`
 
   t.is((await t.context.api.client.get(path,
-    { resolveBodyOnly: false })).statusCode, 200)
+    { resolveBodyOnly: false, throwHttpErrors: false })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    { resolveBodyOnly: false,
+      throwHttpErrors: false,
+      searchParams: { _collections: '' }
+    })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    {
+      resolveBodyOnly: false,
+      searchParams: { _collections: '*' }
+    })).statusCode, 200)
 
   t.is((await t.context.api.client.get(path,
     {

--- a/tests/system/test-api-get-collection.js
+++ b/tests/system/test-api-get-collection.js
@@ -26,6 +26,10 @@ test.before(async (t) => {
   })
 })
 
+test.beforeEach(async (_) => {
+  delete process.env['ENABLE_COLLECTIONS_AUTHX']
+})
+
 test.after.always(async (t) => {
   if (t.context.api) await t.context.api.close()
 })
@@ -66,7 +70,18 @@ test('GET /collections/:collectionId with restriction returns filtered collectio
   const { collectionId } = t.context
 
   t.is((await t.context.api.client.get(`collections/${collectionId}`,
-    { resolveBodyOnly: false })).statusCode, 200)
+    { resolveBodyOnly: false, throwHttpErrors: false })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(`collections/${collectionId}`,
+    { resolveBodyOnly: false,
+      throwHttpErrors: false,
+      searchParams: { _collections: '' },
+    })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(`collections/${collectionId}`,
+    { resolveBodyOnly: false,
+      searchParams: { _collections: '*' },
+    })).statusCode, 200)
 
   t.is((await t.context.api.client.get(`collections/${collectionId}`,
     {

--- a/tests/system/test-api-get-collections.js
+++ b/tests/system/test-api-get-collections.js
@@ -26,6 +26,10 @@ test.before(async (t) => {
   })
 })
 
+test.beforeEach(async (_) => {
+  delete process.env['ENABLE_COLLECTIONS_AUTHX']
+})
+
 test('GET /collections', async (t) => {
   await refreshIndices()
 
@@ -69,6 +73,23 @@ test('GET /collections with restriction returns filtered collections', async (t)
   // enable collections filtering
 
   process.env['ENABLE_COLLECTIONS_AUTHX'] = 'true'
+
+  t.is((await t.context.api.client.get(
+    'collections', { }
+  )
+  ).collections.length, 0)
+
+  t.is((await t.context.api.client.get(
+    'collections', {
+      searchParams: { _collections: '' } }
+  )
+  ).collections.length, 0)
+
+  t.is((await t.context.api.client.get(
+    'collections', {
+      searchParams: { _collections: '*' } }
+  )
+  ).collections.length, 1)
 
   t.is((await t.context.api.client.get(
     'collections', {

--- a/tests/system/test-api-item-get.js
+++ b/tests/system/test-api-item-get.js
@@ -42,6 +42,10 @@ test.before(async (t) => {
   })
 })
 
+test.beforeEach(async (_) => {
+  delete process.env['ENABLE_COLLECTIONS_AUTHX']
+})
+
 test.after.always(async (t) => {
   if (t.context.api) await t.context.api.close()
 })
@@ -89,7 +93,19 @@ test('GET /collections/:collectionId/items/:itemId with restriction returns filt
   const path = `collections/${collectionId}/items/${itemId}`
 
   t.is((await t.context.api.client.get(path,
-    { resolveBodyOnly: false })).statusCode, 200)
+    { resolveBodyOnly: false, throwHttpErrors: false })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    { resolveBodyOnly: false,
+      throwHttpErrors: false,
+      searchParams: { _collections: '' }
+    })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    {
+      resolveBodyOnly: false,
+      searchParams: { _collections: '*' }
+    })).statusCode, 200)
 
   t.is((await t.context.api.client.get(path,
     {
@@ -112,7 +128,21 @@ test('GET /collections/:collectionId/items/:itemId/thumbnail with restriction re
   const path = `collections/${collectionId}/items/${itemId}/thumbnail`
 
   t.is((await t.context.api.client.get(path,
-    { resolveBodyOnly: false, followRedirect: false
+    { resolveBodyOnly: false, throwHttpErrors: false
+    })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    {
+      resolveBodyOnly: false,
+      throwHttpErrors: false,
+      searchParams: { _collections: '' }
+    })).statusCode, 404)
+
+  t.is((await t.context.api.client.get(path,
+    {
+      resolveBodyOnly: false,
+      followRedirect: false,
+      searchParams: { _collections: '*' }
     })).statusCode, 302)
 
   t.is((await t.context.api.client.get(path,

--- a/tests/system/test-api-search-post.js
+++ b/tests/system/test-api-search-post.js
@@ -42,6 +42,10 @@ test.before(async (t) => {
   ])
 })
 
+test.beforeEach(async (_) => {
+  delete process.env['ENABLE_COLLECTIONS_AUTHX']
+})
+
 test.after.always(async (t) => {
   if (t.context.api) await t.context.api.close()
 })
@@ -1375,33 +1379,58 @@ test('POST /search with restriction returns filtered collections', async (t) => 
   const collectionId = 'landsat-8-l1'
   const urlpath = 'search'
 
-  const r1 = await t.context.api.client.post(urlpath,
-    { resolveBodyOnly: false,
-      json: {
-        _collections: [collectionId]
-      } })
+  {
+    const r = await t.context.api.client.post(urlpath,
+      { resolveBodyOnly: false,
+        json: { } })
 
-  t.is(r1.statusCode, 200)
-  t.is(r1.body.features.length, 2)
+    t.is(r.statusCode, 200)
+    t.is(r.body.features.length, 0)
+  }
 
-  const r2 = await t.context.api.client.post(urlpath,
-    { resolveBodyOnly: false,
-      json: {
-        _collections: [collectionId, 'foo', 'bar']
-      } })
+  {
+    const r = await t.context.api.client.post(urlpath,
+      { resolveBodyOnly: false,
+        json: {
+          _collections: []
+        } })
 
-  t.is(r2.statusCode, 200)
-  t.is(r2.body.features.length, 2)
+    t.is(r.statusCode, 200)
+    t.is(r.body.features.length, 0)
+  }
 
-  const r3 = await t.context.api.client.post(urlpath,
-    { resolveBodyOnly: false,
-      json: {
-        _collections: ['not-a-collection']
-      }
-    })
+  {
+    const r = await t.context.api.client.post(urlpath,
+      { resolveBodyOnly: false,
+        json: {
+          _collections: [collectionId]
+        } })
 
-  t.is(r3.statusCode, 200)
-  t.is(r3.body.features.length, 0)
+    t.is(r.statusCode, 200)
+    t.is(r.body.features.length, 2)
+  }
+
+  {
+    const r = await t.context.api.client.post(urlpath,
+      { resolveBodyOnly: false,
+        json: {
+          _collections: [collectionId, 'foo', 'bar']
+        } })
+
+    t.is(r.statusCode, 200)
+    t.is(r.body.features.length, 2)
+  }
+  {
+    const r = await t.context.api.client.post(urlpath,
+      { resolveBodyOnly: false,
+        json: {
+          _collections: ['not-a-collection']
+        }
+      })
+
+    t.is(r.statusCode, 200)
+    t.is(r.body.features.length, 0)
+  }
 })
 
 test('/search - context extension - no context when default', async (t) => {


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-server/issues/886


**Proposed Changes:**

1. Collections Auth features (ENABLE_COLLECTIONS_AUTHX) now fails closed
  rather than open. If `_collections` is not specified or is empty, caller has no
  access to collections. 
2. adds a special collection name `*` that means access
  to all collections is granted.


**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
