### PR TITLE
update default opensearch version from 2.17 to 2.19 to align with AWS current version

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: package.json
       - uses: ankane/setup-opensearch@v1
         with:
-          opensearch-version: 2.17
+          opensearch-version: 2.19
       - name: Upgrade npm
         run: npm install -g npm@10
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Compression is enabled by default, can be disabled by setting
   `ENABLE_RESPONSE_COMPRESSION` to `false`. If using post-hooks, you must update
   to hooks to handle compression or disable compression.
+- Update to default to OpenSearch 2.19
 
 ### Added
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.17.1
+    image: opensearchproject/opensearch:2.19.2
     ports:
       - "127.0.0.1:9200:9200"
       - "127.0.0.1:9300:9300"

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -184,7 +184,7 @@ resources:
           InstanceCount: 1
           DedicatedMasterEnabled: false
           ZoneAwarenessEnabled: false
-        EngineVersion: OpenSearch_2.17
+        EngineVersion: OpenSearch_2.19
         DomainEndpointOptions:
           EnforceHTTPS: true
         NodeToNodeEncryptionOptions:


### PR DESCRIPTION


**Related Issue(s):** 

- n/a


**Proposed Changes:**

1. Update default OpenSearch version to 2.19

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
