### PR TITLE
change from gh-pages deploy to workflow deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,14 +15,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write  # Needed to push to gh-pages branch
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -55,17 +57,30 @@ jobs:
       - name: Install MkDocs dependencies
         run: pip install -r requirements-docs.txt
 
-      - name: Configure Git for MkDocs
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch --depth=1 origin gh-pages || true
-
       - name: Get version from package.json
         id: package-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Deploy documentation with mike
+      - name: Build documentation with mike
         run: |
-          mike deploy --push --update-aliases ${{ steps.package-version.outputs.version }} latest
-          mike set-default --push latest
+          mike deploy --no-redirect ${{ steps.package-version.outputs.version }} latest
+          mike set-default latest
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The deploy from gh-pages has just kept timing out, so switching to workflow based deployment and skipping the gh-pages queue.