### PR TITLE
add missing library to lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17062,6 +17062,16 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",


### PR DESCRIPTION
**Related Issue(s):** 

- Failed doc build -  https://github.com/stac-utils/stac-server/actions/runs/23456579963/job/68247245672
- Failed to run `npm install` before a merge and a library was missing. This hotfix includes the missing library to lead to a successful docs build.


**Proposed Changes:**

1. Updated lockfile

**PR Checklist:**

- [ ] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
