### PR TITLE
ci: pin GitHub Actions to commit SHA digests

### DIFF
--- a/.github/workflows/build-lambda-dist.yml
+++ b/.github/workflows/build-lambda-dist.yml
@@ -11,8 +11,8 @@ jobs:
       PRODUCTION: "true"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         id: setup-node
         with:
           node-version-file: ".nvmrc"
@@ -36,7 +36,7 @@ jobs:
         run: |
           mv dist/lambda-dist/lambda-dist.zip "$DIST_ZIP_PATH"
       - name: Add to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         if: startsWith(github.ref, 'refs/tags')
         with:
           files: ${{ env.DIST_ZIP_PATH }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0  # Fetch all history for git revision dates
 
@@ -38,7 +38,7 @@ jobs:
           ln -sf ../../LICENSE docs/about/license.md
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -50,7 +50,7 @@ jobs:
         run: npm run build-api-docs
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
 
@@ -62,7 +62,7 @@ jobs:
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Setup Git User
-        uses: fregante/setup-git-user@v2
+        uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35 # v2
 
       - name: Build documentation with mike
         run: |
@@ -70,10 +70,10 @@ jobs:
           mike set-default latest
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./site
 
@@ -86,4 +86,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,13 +18,13 @@ jobs:
         ports:
           - 4566:4566
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".nvmrc"
           cache: npm
           cache-dependency-path: package.json
-      - uses: ankane/setup-opensearch@v1
+      - uses: ankane/setup-opensearch@b73d8d2d65eaa5da2add094872f12f3ae6ef1eea # v1
         with:
           opensearch-version: 2.19
       - name: Upgrade npm


### PR DESCRIPTION
## Summary
Closes #1086 — pins all 13 workflow `uses:` references to full commit SHAs (with the version as a trailing comment), removing the tag-mutation supply-chain risk from zizmor's `unpinned-uses` audit.

Generated with `npx pin-github-action .github/workflows/*`. Only the `uses:` lines changed (13 swapped); no structural workflow changes.

The `github-actions` dependabot group (added in #1118) will keep these SHAs and their version comments updated as new releases ship — so pinning doesn't mean going stale.

### Pinned
- `push.yaml`: actions/checkout, actions/setup-node, ankane/setup-opensearch
- `build-lambda-dist.yml`: actions/checkout, actions/setup-node, softprops/action-gh-release
- `docs.yml`: actions/checkout, actions/setup-node, actions/setup-python, fregante/setup-git-user, actions/configure-pages, actions/upload-pages-artifact, actions/deploy-pages

The remaining issue recommendation (zizmor-action in CI for continuous scanning) is left as a optional follow-up.

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)