### PR TITLE
fix: stop emitting undefined:// link hrefs when no endpoint is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Link hrefs no longer start with `undefined://` when neither `STAC_API_URL` nor a
+  `stac-endpoint`/`X-Forwarded-*` header is set (e.g. behind API Gateway, which does
+  not set `X-Forwarded-Proto`/`-Host` by default). The endpoint now falls back to the
+  request's own protocol/host instead of interpolating `undefined`. ([917](https://github.com/stac-utils/stac-server/issues/917))
+
 ### Added
 - Generating base STAC typescript types for typescript migration ([1068](https://github.com/stac-utils/stac-server/pull/1068))
 - Automatic temporal extent calculation for collections. When serving collections via the `/collections`

--- a/src/lambdas/api/middleware/add-endpoint.ts
+++ b/src/lambdas/api/middleware/add-endpoint.ts
@@ -8,13 +8,17 @@ const determineEndpoint = (req: Request): string => {
 
   const rootPath = process.env['STAC_API_ROOTPATH'] || ''
 
-  if (req.get('X-Forwarded-Proto') && req.get('X-Forwarded-Host')) {
-    return `${req.get('X-Forwarded-Proto')}://${req.get('X-Forwarded-Host')}${rootPath}`
-  }
+  // API Gateway (REST) does not set the X-Forwarded-* headers by default, so
+  // fall back to Express's view of the request rather than interpolating
+  // `undefined` into the href — which produced `undefined://...` links (#917).
+  const proto = req.get('X-Forwarded-Proto') || req.protocol || 'https'
+  const forwardedHost = req.get('X-Forwarded-Host')
+  const host = forwardedHost || req.get('Host') || 'localhost'
 
-  return req.event && req.event.requestContext && req.event.requestContext.stage
-    ? `${req.get('X-Forwarded-Proto')}://${req.get('Host')}/${req.event.requestContext.stage}`
-    : `${req.get('X-Forwarded-Proto')}://${req.get('Host')}${rootPath}`
+  if (!forwardedHost && req.event?.requestContext?.stage) {
+    return `${proto}://${host}/${req.event.requestContext.stage}`
+  }
+  return `${proto}://${host}${rootPath}`
 }
 
 export default (req: Request, _res: Response, next: NextFunction) => {

--- a/tests/system/test-api-get-root.ts
+++ b/tests/system/test-api-get-root.ts
@@ -62,9 +62,10 @@ test(
         t.false(link.href.startsWith('undefined://'), `link href was ${link.href}`)
       }
       const self = response.links.find((l: Link) => l.rel === 'self')
-      t.regex(self.href, /^https?:\/\//)
+      t.truthy(self, 'self link present')
+      if (self) t.regex(self.href, /^https?:\/\//)
     } finally {
-      await api.close()
+      if (api) await api.close()
       process.env = before
     }
   }

--- a/tests/system/test-api-get-root.ts
+++ b/tests/system/test-api-get-root.ts
@@ -44,6 +44,33 @@ test('GET / includes the default links', async (t) => {
 })
 
 test(
+  'GET / never emits `undefined://` links when no endpoint is configured (#917)',
+  async (t) => {
+    const before = { ...process.env }
+    let api
+    try {
+      // No configured endpoint and no X-Forwarded-* headers: must still produce
+      // a valid URL from the request, not `undefined://...`.
+      delete process.env['STAC_API_URL']
+      delete process.env['STAC_API_ROOTPATH']
+
+      api = await startApi()
+
+      const response = await api.client.get('')
+
+      for (const link of response.links as Link[]) {
+        t.false(link.href.startsWith('undefined://'), `link href was ${link.href}`)
+      }
+      const self = response.links.find((l: Link) => l.rel === 'self')
+      t.regex(self.href, /^https?:\/\//)
+    } finally {
+      await api.close()
+      process.env = before
+    }
+  }
+)
+
+test(
   'GET / returns links with the correct endpoint when the API was started with STAC_API_URL set',
   async (t) => {
     const before = { ...process.env }

--- a/tests/unit/test-add-endpoint.ts
+++ b/tests/unit/test-add-endpoint.ts
@@ -1,0 +1,107 @@
+import test from 'ava'
+import type { Request, Response } from 'express'
+import addEndpoint from '../../src/lambdas/api/middleware/add-endpoint.js'
+
+type Headers = Record<string, string | undefined>
+
+/**
+ * Build a minimal Express-like Request. `headers` are matched case-insensitively
+ * to mirror `req.get()`. `protocol`, `event`, and env are all overridable so each
+ * fallback branch of `determineEndpoint` can be exercised in isolation.
+ */
+const mockReq = (opts: {
+  headers?: Headers
+  protocol?: string
+  event?: Request['event']
+} = {}): Request => {
+  const headers = opts.headers ?? {}
+  return {
+    protocol: opts.protocol,
+    event: opts.event,
+    get(name: string) {
+      const key = Object.keys(headers).find(
+        (h) => h.toLowerCase() === name.toLowerCase()
+      )
+      return key ? headers[key] : undefined
+    }
+  } as unknown as Request
+}
+
+/** Run the middleware and return the endpoint it assigned to the request. */
+const runEndpoint = (req: Request): string => {
+  let called = false
+  addEndpoint(req, {} as Response, () => { called = true })
+  if (!called) throw new Error('next() was not called')
+  return req.endpoint
+}
+
+// Isolate each test from ambient env (the pre-commit runs may set these).
+test.beforeEach(() => {
+  delete process.env['STAC_API_URL']
+  delete process.env['STAC_API_ROOTPATH']
+})
+
+test.serial('stac-endpoint header takes precedence over everything', (t) => {
+  process.env['STAC_API_URL'] = 'https://from-env.example.com'
+  const req = mockReq({ headers: { 'stac-endpoint': 'https://from-header.example.com' } })
+  t.is(runEndpoint(req), 'https://from-header.example.com')
+})
+
+test.serial('legacy X-STAC-Endpoint header is honored', (t) => {
+  const req = mockReq({ headers: { 'x-stac-endpoint': 'https://legacy.example.com' } })
+  t.is(runEndpoint(req), 'https://legacy.example.com')
+})
+
+test.serial('STAC_API_URL env is used when no endpoint header is set', (t) => {
+  process.env['STAC_API_URL'] = 'https://from-env.example.com'
+  const req = mockReq({ headers: { Host: 'ignored.example.com' }, protocol: 'http' })
+  t.is(runEndpoint(req), 'https://from-env.example.com')
+})
+
+test.serial('X-Forwarded-Proto and X-Forwarded-Host are used together', (t) => {
+  const req = mockReq({
+    headers: { 'X-Forwarded-Proto': 'https', 'X-Forwarded-Host': 'proxy.example.com' }
+  })
+  t.is(runEndpoint(req), 'https://proxy.example.com')
+})
+
+test.serial('STAC_API_ROOTPATH is appended to the forwarded-host endpoint', (t) => {
+  process.env['STAC_API_ROOTPATH'] = '/stac/v1'
+  const req = mockReq({
+    headers: { 'X-Forwarded-Proto': 'https', 'X-Forwarded-Host': 'proxy.example.com' }
+  })
+  t.is(runEndpoint(req), 'https://proxy.example.com/stac/v1')
+})
+
+test.serial('falls back to req.protocol and Host when nothing is forwarded', (t) => {
+  const req = mockReq({ headers: { Host: 'direct.example.com' }, protocol: 'http' })
+  t.is(runEndpoint(req), 'http://direct.example.com')
+})
+
+test.serial('defaults to https://localhost when protocol and Host are absent (#917)', (t) => {
+  // The API Gateway case: no configured endpoint, no forwarded headers, and
+  // Express reports no usable protocol/host. Must never yield `undefined://...`.
+  const req = mockReq({})
+  const endpoint = runEndpoint(req)
+  t.is(endpoint, 'https://localhost')
+  t.false(endpoint.startsWith('undefined://'))
+})
+
+test.serial('appends the API Gateway stage when present and no forwarded host', (t) => {
+  const req = mockReq({
+    headers: { Host: 'abc123.execute-api.us-west-2.amazonaws.com' },
+    protocol: 'https',
+    event: { requestContext: { stage: 'prod' } } as Request['event']
+  })
+  t.is(runEndpoint(req), 'https://abc123.execute-api.us-west-2.amazonaws.com/prod')
+})
+
+test.serial('a forwarded host suppresses the stage segment', (t) => {
+  // With X-Forwarded-Host present the proxy owns the public path, so the raw
+  // Lambda stage must not be appended.
+  const req = mockReq({
+    headers: { 'X-Forwarded-Proto': 'https', 'X-Forwarded-Host': 'proxy.example.com' },
+    event: { requestContext: { stage: 'prod' } } as Request['event']
+  })
+  t.is(runEndpoint(req), 'https://proxy.example.com')
+})


### PR DESCRIPTION
## Summary
Minimal 5.0.1 fix for #917. `determineEndpoint` interpolated `req.get('X-Forwarded-Proto')` (and `Host`) straight into the href in its fallback branches. API Gateway (REST) doesn't set `X-Forwarded-*` by default, so with no `STAC_API_URL` or `stac-endpoint` header the protocol was `undefined` → `undefined://host/...` links.

## Change
Fall back to Express's own `req.protocol` / `Host` (defaulting to `https` / `localhost`) so a valid URL is always produced. **Behavior is unchanged** for the already-working, tested cases:
- `stac-endpoint` / `X-STAC-Endpoint` header
- `STAC_API_URL` env
- `X-Forwarded-Proto` + `X-Forwarded-Host`

Only the previously-broken "nothing configured" path changes — from `undefined://…` to a request-derived URL.

## Test
Adds a regression test asserting no link href starts with `undefined://` when nothing is configured; all existing endpoint tests still pass.

## Scope note
This is intentionally the **narrow symptom fix** for 5.0.1. The middleware has deeper design issues (proprietary `X-STAC-Endpoint` vs standard forwarded headers, no `X-Forwarded-Prefix` support, env-over-header precedence, host-header-injection exposure). I've written those up as a comment on #917 for a future redesign rather than expanding this patch.

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)