### PR TITLE
build: stub optional aws-crt/aws-sdk to remove webpack build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Remove the webpack "Can't resolve" build warning for optional, unused AWS SDK
+  dependencies (`aws-crt`, and the OpenSearch client's optional `aws-sdk` v2
+  credential path) by stubbing them via `resolve.fallback` in the lambda webpack
+  configs. ([596](https://github.com/stac-utils/stac-server/issues/596))
+
 ### Added
 - Generating base STAC typescript types for typescript migration ([1068](https://github.com/stac-utils/stac-server/pull/1068))
 - Automatic temporal extent calculation for collections. When serving collections via the `/collections`

--- a/src/lambdas/api/webpack.config.js
+++ b/src/lambdas/api/webpack.config.js
@@ -26,6 +26,7 @@ export default {
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],
+    fallback: { 'aws-crt': false, 'aws-sdk': false },
     extensionAlias: {
       ".js": [".ts", ".js"],
     },

--- a/src/lambdas/ingest/webpack.config.js
+++ b/src/lambdas/ingest/webpack.config.js
@@ -25,6 +25,7 @@ export default {
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],
+    fallback: { 'aws-crt': false, 'aws-sdk': false },
     extensionAlias: {
       ".js": [".ts", ".js"],
     },

--- a/src/lambdas/post-hook/webpack.config.js
+++ b/src/lambdas/post-hook/webpack.config.js
@@ -25,6 +25,7 @@ export default {
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],
+    fallback: { 'aws-crt': false, 'aws-sdk': false },
     extensionAlias: {
       ".js": [".ts", ".js"],
     },

--- a/src/lambdas/pre-hook/webpack.config.js
+++ b/src/lambdas/pre-hook/webpack.config.js
@@ -25,6 +25,7 @@ export default {
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],
+    fallback: { 'aws-crt': false, 'aws-sdk': false },
     extensionAlias: {
       ".js": [".ts", ".js"],
     },

--- a/src/lambdas/webpack.config.js
+++ b/src/lambdas/webpack.config.js
@@ -31,6 +31,7 @@ export default {
   devtool,
   resolve: {
     extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"],
+    fallback: { 'aws-crt': false, 'aws-sdk': false },
     extensionAlias: {
       ".js": [".ts", ".js"],
     },


### PR DESCRIPTION
## Summary
Closes #596. The build emitted `Module not found: Can't resolve 'aws-crt'` (and, after the AWS SDK v3 updates, the equivalent `Can't resolve 'aws-sdk'` from the OpenSearch client's `AwsSigv4Signer`) — optional dependencies that stac-server never uses at runtime.

## Change
Add `resolve.fallback: { 'aws-crt': false, 'aws-sdk': false }` to all five lambda webpack configs (api, ingest, pre-hook, post-hook, and the lambda-dist bundle). webpack then resolves these optional modules to empty instead of warning.

Safe because:
- `aws-crt` is an optional native dep the SDK probes for and gracefully does without.
- `aws-sdk` (v2) is only used by `AwsSigv4Signer` when no `getCredentials` is supplied — stac-server always supplies a v3 `defaultProvider()` (`database-client.ts`), so that path is dead code.

## Verification
`npm run build` goes from 2 warnings to 1 — the `aws-sdk`/`aws-crt` "Can't resolve" warning is gone (`aws-sdk (ignored)`). The two remaining warnings (`express/lib/view.js`, `keyv/src/index.js`) are unrelated benign dynamic-require internals, out of scope for this issue.

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)