### PR TITLE
PR audit findings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,14 @@
 #!/usr/bin/env sh
 
-# Load nvm
-export NVM_DIR="$HOME/.nvm"
+# Load nvm if available
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-# Use project's Node version
-if [ -f .nvmrc ]; then
+# Select the project's Node version via nvm when it's available. When nvm is not
+# installed (e.g. Node provided by Nix or a system package manager), just use
+# whatever node is on PATH — it's up to the developer to run a compatible Node,
+# and CI enforces the pinned version regardless.
+if [ -f .nvmrc ] && command -v nvm >/dev/null 2>&1; then
   nvm use
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Upgrade `got` from 13 to 15 (HTTP client used by the ingest lambda for fetching remote STAC records). No API or behavior changes; remote-record fetches keep lenient Content-Length handling. `got` 15 requires Node.js >= 22, now declared in `engines` and used by all CI workflows.
+- Corrected STAC types: `StacItem.bbox` is now `BBox` (matching the STAC document
+  model, with the request-string form kept only on `APIParameters`), and
+  collection `summaries` now accept range objects and JSON Schema values in
+  addition to value arrays, per the STAC spec.
 - Typing the top level lambda layer ([1087](https://github.com/stac-utils/stac-server/pull/1087))
 - Typing the api layer in `api.ts`, pushing some minor functions to a new utility files `api-utils.ts` ([1081](https://github.com/stac-utils/stac-server/pull/1081))
 - Converting the database layer to typescript as part of migration ([1077](https://github.com/stac-utils/stac-server/pull/1077))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Re-enabled AVA worker threads for the test suites by registering the `tsx`
+  loader via AVA's `nodeArguments` config instead of `NODE_OPTIONS`, removing the
+  `--no-worker-threads` workaround introduced during the TypeScript migration.
 
 - The `datetime_frequency` aggregation now honors the `datetime_frequency_interval`
   parameter (`day`/`week`/`month`/`quarter`/`year`) instead of always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Searches restrict to the requested collections via an `_index` filter in the
+  query body rather than listing indices in the request path. This avoids the
+  OpenSearch request-URL length limit when many collections are requested,
+  without falling back to searching all indices. ([770](https://github.com/stac-utils/stac-server/issues/770))
 - Re-enabled AVA worker threads for the test suites by registering the `tsx`
   loader via AVA's `nodeArguments` config instead of `NODE_OPTIONS`, removing the
   `--no-worker-threads` workaround introduced during the TypeScript migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Post-ingest SNS notifications now report `ingestStatus` as `failed` for any
+  ingest error, including errors whose message is empty. Previously the status
+  was derived from the truthiness of the error message, so an empty-message
+  error was mis-reported as `successful`. ([1155](https://github.com/stac-utils/stac-server/pull/1155))
 - Searches restrict to the requested collections via an `_index` filter in the
   query body rather than listing indices in the request path. This avoids the
   OpenSearch request-URL length limit when many collections are requested,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Automatic temporal extent calculation no longer discards a collection's declared
+  temporal sub-intervals. Only the overall extent (`interval[0]`) is computed from
+  items; any finer-grained sub-intervals (`interval[1..n]`) declared on the
+  collection are now preserved instead of being overwritten with a single computed
+  interval. ([1155](https://github.com/stac-utils/stac-server/pull/1155))
 - Post-ingest SNS notifications now report `ingestStatus` as `failed` for any
   ingest error, including errors whose message is empty. Previously the status
   was derived from the truthiness of the error message, so an empty-message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Searches restrict to the requested collections via an `_index` filter in the
   query body rather than listing indices in the request path. This avoids the
   OpenSearch request-URL length limit when many collections are requested,
-  without falling back to searching all indices. ([770](https://github.com/stac-utils/stac-server/issues/770))
+  without falling back to searching all indices. ([770](https://github.com/stac-utils/stac-server/issues/770), [1155](https://github.com/stac-utils/stac-server/pull/1155))
 - Re-enabled AVA worker threads for the test suites by registering the `tsx`
   loader via AVA's `nodeArguments` config instead of `NODE_OPTIONS`, removing the
-  `--no-worker-threads` workaround introduced during the TypeScript migration.
+  `--no-worker-threads` workaround introduced during the TypeScript migration. ([1155](https://github.com/stac-utils/stac-server/pull/1155))
 
 - The `datetime_frequency` aggregation now honors the `datetime_frequency_interval`
   parameter (`day`/`week`/`month`/`quarter`/`year`) instead of always
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Corrected STAC types: `StacItem.bbox` is now `BBox` (matching the STAC document
   model, with the request-string form kept only on `APIParameters`), and
   collection `summaries` now accept range objects and JSON Schema values in
-  addition to value arrays, per the STAC spec.
+  addition to value arrays, per the STAC spec. ([1155](https://github.com/stac-utils/stac-server/pull/1155))
 - Typing the top level lambda layer ([1087](https://github.com/stac-utils/stac-server/pull/1087))
 - Typing the api layer in `api.ts`, pushing some minor functions to a new utility files `api-utils.ts` ([1081](https://github.com/stac-utils/stac-server/pull/1081))
 - Converting the database layer to typescript as part of migration ([1077](https://github.com/stac-utils/stac-server/pull/1077))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Scoped searches over collections configured with `COLLECTION_TO_INDEX_MAPPINGS`
+  now target the mapped index name directly. Previously the mapped name was
+  re-hashed as if it were a collection id, producing a nonexistent index and
+  returning no results for those collections. Collections without a mapping entry
+  continue to resolve to their hashed index name.
+  ([1155](https://github.com/stac-utils/stac-server/pull/1155))
 - Automatic temporal extent calculation no longer discards a collection's declared
   temporal sub-intervals. Only the overall extent (`interval[0]`) is computed from
   items; any finer-grained sub-intervals (`interval[1..n]`) declared on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   ingest error, including errors whose message is empty. Previously the status
   was derived from the truthiness of the error message, so an empty-message
   error was mis-reported as `successful`. ([1155](https://github.com/stac-utils/stac-server/pull/1155))
-- Searches restrict to the requested collections via an `_index` filter in the
-  query body rather than listing indices in the request path. This avoids the
-  OpenSearch request-URL length limit when many collections are requested,
-  without falling back to searching all indices. ([770](https://github.com/stac-utils/stac-server/issues/770), [1155](https://github.com/stac-utils/stac-server/pull/1155))
+- Searches with too many collections no longer fail with an OpenSearch
+  request-URL length error, and no longer fall back to searching all indices.
+  Collections are scoped in the request path as before when the index list is
+  short; only when it would overflow the URL length limit does the search fall
+  back to an `_index` filter in the query body, preserving index scoping either
+  way. ([770](https://github.com/stac-utils/stac-server/issues/770), [1155](https://github.com/stac-utils/stac-server/pull/1155))
 - Re-enabled AVA worker threads for the test suites by registering the `tsx`
   loader via AVA's `nodeArguments` config instead of `NODE_OPTIONS`, removing the
   `--no-worker-threads` workaround introduced during the TypeScript migration. ([1155](https://github.com/stac-utils/stac-server/pull/1155))

--- a/bin/system-tests.sh
+++ b/bin/system-tests.sh
@@ -10,14 +10,12 @@ export ENABLE_TRANSACTIONS_EXTENSION=true
 export REQUEST_LOGGING_ENABLED=false
 # export ENABLE_RESPONSE_COMPRESSION=false
 
-# Force ALL Node processes (including AVA workers) to use tsx
-export NODE_OPTIONS="--import=tsx"
-
 echo "Running tests"
 set +e
 
 # add --match to restrict by test name
-npx ava "tests/system/${TEST_PATTERN}" --serial --verbose --no-worker-threads
+# tsx is registered via the ava `nodeArguments` config in package.json
+npx ava "tests/system/${TEST_PATTERN}" --serial --verbose
 TEST_RESULT="$?"
 set -e
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "npm run test:unit && npm run test:system",
     "test:system": "./bin/system-tests.sh",
     "test:system:coverage": "c8 npm run test:system",
-    "test:unit": "NODE_OPTIONS='--import=tsx' ava tests/unit/*.[tj]s --no-worker-threads",
+    "test:unit": "ava tests/unit/*.[tj]s",
     "test:unit:coverage": "c8 npm run test:unit",
     "typecheck": "tsc && tsc -p tsconfig.test.json",
     "audit-prod": "npx better-npm-audit audit --production",
@@ -37,6 +37,9 @@
     "timeout": "1m",
     "extensions": [
       "ts"
+    ],
+    "nodeArguments": [
+      "--import=tsx"
     ]
   },
   "publishConfig": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1065,16 +1065,23 @@ const populateTemporalExtentIfMissing = async (
   backend: Backend,
   collection: StacCollection
 ): Promise<void> => {
-  const [start, end] = collection.extent?.temporal?.interval?.[0] ?? [null, null]
+  const intervals = collection.extent?.temporal?.interval
+  const [start, end] = intervals?.[0] ?? [null, null]
 
-  // Nothing to do when both bounds are already declared.
+  // Nothing to do when both bounds of the overall extent are already declared.
   if (start != null && end != null) return
 
   const temporalExtent = await backend.getTemporalExtentFromItems(collection.id)
   if (temporalExtent && collection.extent?.temporal) {
     const [computedStart, computedEnd] = temporalExtent[0]
-    // Preserve any declared bound; only fill the missing one(s) from items.
-    collection.extent.temporal.interval = [[start ?? computedStart, end ?? computedEnd]]
+    // Only the overall extent (interval[0]) is computed from items; any declared
+    // sub-intervals (interval[1..n]) are preserved, as is any bound already set
+    // on the overall extent.
+    const rest = intervals?.slice(1) ?? []
+    collection.extent.temporal.interval = [
+      [start ?? computedStart, end ?? computedEnd],
+      ...rest
+    ]
   }
 }
 

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -78,7 +78,6 @@ export const DEFAULT_FIELDS = [
   'collection',
   'properties.datetime'
 ]
-const MAX_COLLECTIONS_IN_QUERY_PATH = 10
 
 let collectionToIndexMapping: Record<string, string> | null = null
 let unrestrictedIndices: string[] | null = null
@@ -523,6 +522,15 @@ function buildItemSearchQuery(parameters: QueryParameters): OpenSearchFilterQuer
   }
 }
 
+// Normalise a bool `filter`/`must_not` clause, which may be a single query
+// object or an array, into an array.
+function toFilterArray(
+  v: OpenSearchFilterQuery | OpenSearchFilterQuery[] | undefined
+): OpenSearchFilterQuery[] {
+  if (!v) return []
+  return Array.isArray(v) ? v : [v]
+}
+
 function buildOpenSearchQuery(parameters: QueryParameters): OpenSearchBody {
   const { query, filter, intersects, collections, ids } = parameters
 
@@ -547,25 +555,17 @@ function buildOpenSearchQuery(parameters: QueryParameters): OpenSearchBody {
     itemSearchQuery = buildItemSearchQuery(parameters)
   }
 
-  // Normalise filter/must_not which can be single item or array
-  const toArray = (
-    v: OpenSearchFilterQuery | OpenSearchFilterQuery[] | undefined
-  ): OpenSearchFilterQuery[] => {
-    if (!v) return []
-    return Array.isArray(v) ? v : [v]
-  }
-
   const combinedFilter: OpenSearchFilterQuery[] = [
-    ...toArray(cql2Query.bool?.filter),
-    ...toArray(stacqlQuery.bool?.filter),
-    ...toArray(itemSearchQuery.bool?.filter)
+    ...toFilterArray(cql2Query.bool?.filter),
+    ...toFilterArray(stacqlQuery.bool?.filter),
+    ...toFilterArray(itemSearchQuery.bool?.filter)
   ]
   const combinedShould: OpenSearchFilterQuery[] = [
     ...(cql2Query.bool?.should || []),
   ]
   const combinedMustNot: OpenSearchFilterQuery[] = [
-    ...toArray(cql2Query.bool?.must_not),
-    ...toArray(stacqlQuery.bool?.must_not),
+    ...toFilterArray(cql2Query.bool?.must_not),
+    ...toFilterArray(stacqlQuery.bool?.must_not),
   ]
 
   if (!isEmpty(combinedFilter)) {
@@ -584,6 +584,32 @@ function buildOpenSearchQuery(parameters: QueryParameters): OpenSearchBody {
   }
 
   return { query: { bool: osBool } }
+}
+
+/**
+ * Restrict a query to a set of indices by adding a `terms` filter on the
+ * `_index` metadata field, rather than listing the indices in the request path.
+ *
+ * OpenSearch puts the path-based index list in the request URL, which is subject
+ * to the server's `http.max_initial_line_length` limit (4KB by default). A search
+ * spanning many collections can exceed that and fail. Moving the index
+ * restriction into the request body, which has no comparable limit, keeps the
+ * search scoped to the relevant indices without the cliff. See issue #770.
+ */
+function restrictQueryToIndices(
+  body: OpenSearchBody, indices: string[]
+): OpenSearchBody {
+  const indexFilter: OpenSearchFilterQuery = { terms: { _index: indices } }
+
+  // match_all means there are no other constraints; wrap it so we can filter.
+  if (body.query.match_all) {
+    return { ...body, query: { bool: { filter: [indexFilter] } } }
+  }
+
+  const bool = body.query.bool ?? {}
+  const filter = [...toFilterArray(bool.filter), indexFilter]
+
+  return { ...body, query: { ...body.query, bool: { ...bool, filter } } }
 }
 
 function buildIdQuery(id: string): OpenSearchBody {
@@ -914,32 +940,34 @@ export async function constructSearchParams(
     body.search_after = buildSearchAfter(parameters)
   }
 
-  let indices
+  // The request path always uses the default index restriction
+  // (`*, -.*, -collections`): all local item indices, excluding system indices
+  // and the collections index. This is a fixed, short list that never overflows
+  // the request URL's line-length limit.
+  if (!unrestrictedIndices) {
+    await populateUnrestrictedIndices()
+  }
+  const index = unrestrictedIndices!
+
   if (Array.isArray(collections) && collections.length) {
-    if (collections.length > MAX_COLLECTIONS_IN_QUERY_PATH) {
-      indices = ['_all']
-    } else if (process.env['COLLECTION_TO_INDEX_MAPPINGS']) {
+    // Resolve the explicitly-requested collections to their (hashed) indices and
+    // scope the search to them via an `_index` filter in the request body rather
+    // than the path. Listing many indices in the path can overflow the URL's
+    // line-length limit; the body has no comparable limit. The path keeps the
+    // default restriction above so the search never reaches into system indices.
+    let indices
+    if (process.env['COLLECTION_TO_INDEX_MAPPINGS']) {
       if (!collectionToIndexMapping) await populateCollectionToIndexMapping()
       indices = await Promise.all(collections.map(async (x) => await indexForCollection(x)))
     } else {
       indices = collections
     }
-  } else {
-    if (!unrestrictedIndices) {
-      await populateUnrestrictedIndices()
-    }
-    indices = unrestrictedIndices!
+    indices = indices.map((i) => collectionUniqueIndexID(i))
+    body = restrictQueryToIndices(body, indices)
   }
-  // hash indices
-  indices = indices.map((index) => {
-    if (DEFAULT_INDICES.includes(index) || index === '_all') {
-      return index
-    }
-    return collectionUniqueIndexID(index)
-  })
 
   const searchParams: SearchParameters = {
-    index: indices,
+    index,
     body,
     size: limit,
     track_total_hits: true

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -480,6 +480,22 @@ export function collectionUniqueIndexID(collectionId: string): string {
   return `${collectionId.toLowerCase()}-${collectionHash(collectionId)}`
 }
 
+/**
+ * Resolve a list of collection ids to the OpenSearch index names to search.
+ *
+ * A collection present in the `COLLECTION_TO_INDEX_MAPPINGS` mapping resolves to
+ * its configured index name and is used as-is (it may be a shared or remote index
+ * that must not be altered). Any other collection — including every collection
+ * when the mapping is empty — resolves to the hashed index name derived from its
+ * id. This matches how mapping values are used in populateUnrestrictedIndices.
+ */
+export function resolveCollectionIndices(
+  collections: string[],
+  mapping: Record<string, string>
+): string[] {
+  return collections.map((c) => mapping[c] ?? collectionUniqueIndexID(c))
+}
+
 function buildItemSearchQuery(parameters: QueryParameters): OpenSearchFilterQuery {
   const { intersects, collections, ids } = parameters
   const filterQueries: OpenSearchFilterQuery[] = []
@@ -895,10 +911,6 @@ async function populateCollectionToIndexMapping() {
   }
 }
 
-async function indexForCollection(collectionId: string): Promise<string> {
-  return (collectionToIndexMapping ?? {})[collectionId] || collectionId
-}
-
 async function populateUnrestrictedIndices() {
   if (!unrestrictedIndices) {
     if (process.env['COLLECTION_TO_INDEX_MAPPINGS']) {
@@ -950,19 +962,15 @@ export async function constructSearchParams(
   const index = unrestrictedIndices!
 
   if (Array.isArray(collections) && collections.length) {
-    // Resolve the explicitly-requested collections to their (hashed) indices and
-    // scope the search to them via an `_index` filter in the request body rather
-    // than the path. Listing many indices in the path can overflow the URL's
+    // Resolve the explicitly-requested collections to their indices and scope
+    // the search to them via an `_index` filter in the request body rather than
+    // the path. Listing many indices in the path can overflow the URL's
     // line-length limit; the body has no comparable limit. The path keeps the
     // default restriction above so the search never reaches into system indices.
-    let indices
-    if (process.env['COLLECTION_TO_INDEX_MAPPINGS']) {
-      if (!collectionToIndexMapping) await populateCollectionToIndexMapping()
-      indices = await Promise.all(collections.map(async (x) => await indexForCollection(x)))
-    } else {
-      indices = collections
+    if (process.env['COLLECTION_TO_INDEX_MAPPINGS'] && !collectionToIndexMapping) {
+      await populateCollectionToIndexMapping()
     }
-    indices = indices.map((i) => collectionUniqueIndexID(i))
+    const indices = resolveCollectionIndices(collections, collectionToIndexMapping ?? {})
     body = restrictQueryToIndices(body, indices)
   }
 

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -604,13 +604,15 @@ function buildOpenSearchQuery(parameters: QueryParameters): OpenSearchBody {
 
 /**
  * Restrict a query to a set of indices by adding a `terms` filter on the
- * `_index` metadata field, rather than listing the indices in the request path.
+ * `_index` metadata field.
  *
- * OpenSearch puts the path-based index list in the request URL, which is subject
- * to the server's `http.max_initial_line_length` limit (4KB by default). A search
- * spanning many collections can exceed that and fail. Moving the index
- * restriction into the request body, which has no comparable limit, keeps the
- * search scoped to the relevant indices without the cliff. See issue #770.
+ * This is the fallback for when the index list is too long to list in the request
+ * path: OpenSearch puts the path-based index list in the request URL, which is
+ * subject to the server's `http.max_initial_line_length` limit (4KB by default),
+ * so a search spanning many collections can exceed that and fail. The body has no
+ * comparable limit, so this keeps the search scoped without the cliff. The search
+ * must then be sent to a broad path (the default restriction) for the `_index`
+ * filter to narrow against. See issue #770.
  */
 function restrictQueryToIndices(
   body: OpenSearchBody, indices: string[]
@@ -626,6 +628,17 @@ function restrictQueryToIndices(
   const filter = [...toFilterArray(bool.filter), indexFilter]
 
   return { ...body, query: { ...body.query, bool: { ...bool, filter } } }
+}
+
+// The comma-joined index list goes in the request path, which shares OpenSearch's
+// `http.max_initial_line_length` budget (4KB by default) with the method, the
+// rest of the path, the query string, and URL-encoding expansion. Cap the joined
+// index list well below that so the rest of the request line always fits; longer
+// lists fall back to an `_index` body filter instead.
+const MAX_INDEX_PATH_LENGTH = 2048
+
+function indexPathWithinLimit(indices: string[]): boolean {
+  return indices.join(',').length <= MAX_INDEX_PATH_LENGTH
 }
 
 function buildIdQuery(id: string): OpenSearchBody {
@@ -952,26 +965,33 @@ export async function constructSearchParams(
     body.search_after = buildSearchAfter(parameters)
   }
 
-  // The request path always uses the default index restriction
-  // (`*, -.*, -collections`): all local item indices, excluding system indices
-  // and the collections index. This is a fixed, short list that never overflows
-  // the request URL's line-length limit.
+  // Default index restriction used when no collections are requested:
+  // `*, -.*, -collections` (all local item indices, excluding system indices and
+  // the collections index).
   if (!unrestrictedIndices) {
     await populateUnrestrictedIndices()
   }
-  const index = unrestrictedIndices!
+  let index = unrestrictedIndices!
 
   if (Array.isArray(collections) && collections.length) {
-    // Resolve the explicitly-requested collections to their indices and scope
-    // the search to them via an `_index` filter in the request body rather than
-    // the path. Listing many indices in the path can overflow the URL's
-    // line-length limit; the body has no comparable limit. The path keeps the
-    // default restriction above so the search never reaches into system indices.
+    // Resolve the explicitly-requested collections to their indices.
     if (process.env['COLLECTION_TO_INDEX_MAPPINGS'] && !collectionToIndexMapping) {
       await populateCollectionToIndexMapping()
     }
     const indices = resolveCollectionIndices(collections, collectionToIndexMapping ?? {})
-    body = restrictQueryToIndices(body, indices)
+
+    // Prefer scoping in the request path: OpenSearch prunes to those shards at
+    // the coordinating node before fan-out, which is cheaper than searching all
+    // indices and filtering per-shard. But the path is part of the request URL,
+    // so a long index list can overflow the server's line-length limit; in that
+    // case fall back to an `_index` terms filter in the request body (which has
+    // no comparable limit), leaving the path at the default restriction so it
+    // never reaches into system indices.
+    if (indexPathWithinLimit(indices)) {
+      index = indices
+    } else {
+      body = restrictQueryToIndices(body, indices)
+    }
   }
 
   const searchParams: SearchParameters = {

--- a/src/lib/sns.ts
+++ b/src/lib/sns.ts
@@ -6,6 +6,8 @@ import { StacRecord } from './types.js'
 
 interface SNSPayload {
   record: StacRecord
+  // The ingest error message, or `undefined` when ingestion succeeded. An empty
+  // string is a failure with no message, not a success.
   error: string | undefined
 }
 /**
@@ -36,7 +38,9 @@ const attrsFromPayload = function (
     },
     ingestStatus: {
       DataType: 'String',
-      StringValue: payload.error ? 'failed' : 'successful'
+      // Presence of an error, not its message text, determines failure: an
+      // error with an empty message still means the ingest failed.
+      StringValue: payload.error !== undefined ? 'failed' : 'successful'
     },
     collection: {
       DataType: 'String',

--- a/src/lib/stac-utils.ts
+++ b/src/lib/stac-utils.ts
@@ -87,7 +87,7 @@ export function getStartAndEndDates(
   return { startDate, endDate }
 }
 
-export function getBBox(record: StacRecord): string | BBox | undefined {
+export function getBBox(record: StacRecord): BBox | undefined {
   if (isCollection(record)) {
     return record.extent?.spatial?.bbox?.length > 0
       ? record.extent.spatial.bbox[0]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,8 +11,8 @@ export interface StacItem {
   stac_version: string
   stac_extensions?: string[]
   id: string
-  geometry: Geometry| null
-  bbox?: BBox | string // only required if geometry is not null
+  geometry: Geometry | null
+  bbox?: BBox // only required if geometry is not null
   properties: ItemProperties
   links: Link[]
   assets: Assets
@@ -37,7 +37,7 @@ export interface StacCollection {
   extent: Extent
   queryables?: Queryables
   aggregations?: Aggregation[]
-  summaries?: {[key: string]: string[] | number[]}
+  summaries?: {[key: string]: Summary}
   links: Link[]
   assets?: Assets
   item_assets?: {[key: string]: Asset}
@@ -47,6 +47,25 @@ export interface FeatureCollection {
   type: 'FeatureCollection',
   features: StacItem[]
 }
+
+/**
+ * A Range Object summary. Per the STAC spec a range may be open-ended, so a
+ * bound may be omitted; at least one of `minimum`/`maximum` is present.
+ */
+export type SummaryRange =
+  | { minimum: string | number, maximum?: string | number }
+  | { maximum: string | number, minimum?: string | number }
+
+/**
+ * A collection summary. Per the STAC spec a summary may be a set of distinct
+ * values, a Range Object with `minimum`/`maximum` bounds, or a JSON Schema
+ * describing the values.
+ * https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#summaries
+ */
+export type Summary =
+  | Array<string | number | boolean>
+  | SummaryRange
+  | { [key: string]: unknown } // JSON Schema
 
 export interface StacCatalog {
   stac_version: string

--- a/tests/system/test-api-temporal-extent.ts
+++ b/tests/system/test-api-temporal-extent.ts
@@ -156,3 +156,67 @@ test('Collection with no items has null temporal extent', async (t) => {
   // but our code should gracefully handle this (return null or keep original)
   t.truthy(response.body.extent)
 })
+
+test('Declared sub-intervals are preserved when the overall extent is computed', async (t) => {
+  // A collection whose overall extent (interval[0]) has a missing end, plus two
+  // declared finer-grained sub-intervals (interval[1..n]). Only the overall
+  // extent should be filled from items; the sub-intervals must survive.
+  const multiIntervalId = randomId('multi-interval-collection')
+  const multiIntervalCollection = await loadFixture(
+    'landsat-8-l1-collection.json',
+    {
+      id: multiIntervalId,
+      extent: {
+        spatial: { bbox: [[-180, -90, 180, 90]] },
+        temporal: {
+          interval: [
+            ['2013-06-01T00:00:00Z', null],
+            ['2015-01-01T00:00:00Z', '2016-01-01T00:00:00Z'],
+            ['2018-01-01T00:00:00Z', '2019-01-01T00:00:00Z']
+          ]
+        }
+      }
+    }
+  )
+
+  await ingestItem({
+    ingestQueueUrl: t.context.ingestQueueUrl,
+    ingestTopicArn: t.context.ingestTopicArn,
+    item: multiIntervalCollection
+  })
+
+  // Give the collection an item so the overall extent's missing end is computed.
+  const item = await loadFixture('stac/LC80100102015050LGN00.json', {
+    collection: multiIntervalId,
+    id: randomId('item'),
+    properties: {
+      datetime: '2020-06-15T10:30:00.000Z'
+    }
+  })
+
+  await ingestItem({
+    ingestQueueUrl: t.context.ingestQueueUrl,
+    ingestTopicArn: t.context.ingestTopicArn,
+    item
+  })
+
+  await refreshIndices()
+
+  const response = await t.context.api.client.get(`collections/${multiIntervalId}`,
+    { resolveBodyOnly: false })
+
+  t.is(response.statusCode, 200)
+  t.is(response.body.id, multiIntervalId)
+
+  const { interval } = response.body.extent.temporal
+
+  // All three intervals must remain — the sub-intervals are not discarded.
+  t.is(interval.length, 3)
+
+  // Overall extent: declared start preserved, missing end computed from items.
+  t.deepEqual(interval[0], ['2013-06-01T00:00:00Z', '2020-06-15T10:30:00.000Z'])
+
+  // Declared sub-intervals are untouched.
+  t.deepEqual(interval[1], ['2015-01-01T00:00:00Z', '2016-01-01T00:00:00Z'])
+  t.deepEqual(interval[2], ['2018-01-01T00:00:00Z', '2019-01-01T00:00:00Z'])
+})

--- a/tests/unit/test-asset-proxy.ts
+++ b/tests/unit/test-asset-proxy.ts
@@ -202,12 +202,13 @@ test('AssetProxy - getProxiedAssets() handles assets without href', async (t) =>
     process.env['ASSET_PROXY_BUCKET_OPTION'] = 'ALL'
 
     const proxy = await AssetProxy.create()
-    const assets: Assets = {
+    // Deliberately omit `href` to exercise the missing-href branch; cast because
+    // the Assets type requires href.
+    const assets = {
       metadata: {
-        href: '',
         type: 'application/xml'
       }
-    }
+    } as unknown as Assets
 
     const { assets: proxied, wasProxied } = proxy.getProxiedAssets(
       assets,
@@ -217,7 +218,7 @@ test('AssetProxy - getProxiedAssets() handles assets without href', async (t) =>
     )
 
     t.false(wasProxied)
-    t.deepEqual(proxied['metadata'], { href: '', type: 'application/xml' })
+    t.deepEqual(proxied['metadata'], { type: 'application/xml' })
   } finally {
     process.env = before
   }

--- a/tests/unit/test-es.ts
+++ b/tests/unit/test-es.ts
@@ -2,7 +2,8 @@ import test from 'ava'
 import {
   constructSearchParams,
   buildDatetimeQuery,
-  collectionUniqueIndexID
+  collectionUniqueIndexID,
+  resolveCollectionIndices
 } from '../../src/lib/database.js'
 import type { OpenSearchFilterQuery, QueryParameters } from '../../src/lib/types.js'
 
@@ -101,5 +102,39 @@ test('collections are scoped via an _index filter in the body, not the path', as
   t.deepEqual(
     indexFilter?.terms?.['_index'],
     collections.map((c) => collectionUniqueIndexID(c))
+  )
+})
+
+test('resolveCollectionIndices hashes every collection id when the mapping is empty', (t) => {
+  const collections = ['a', 'b', 'c']
+  t.deepEqual(
+    resolveCollectionIndices(collections, {}),
+    collections.map((c) => collectionUniqueIndexID(c))
+  )
+})
+
+test('resolveCollectionIndices uses a mapped index name as-is, without hashing', (t) => {
+  const mapping = { a: 'shared-index', b: 'cluster:remote-index' }
+  t.deepEqual(
+    resolveCollectionIndices(['a', 'b'], mapping),
+    ['shared-index', 'cluster:remote-index']
+  )
+})
+
+test('resolveCollectionIndices falls back to the hashed id for unmapped collections', (t) => {
+  // In mapping mode, a collection absent from the mapping must still resolve to
+  // its hashed index name, not its raw id.
+  const mapping = { a: 'shared-index' }
+  t.deepEqual(
+    resolveCollectionIndices(['a', 'b'], mapping),
+    ['shared-index', collectionUniqueIndexID('b')]
+  )
+})
+
+test('resolveCollectionIndices handles a mix of mapped and unmapped collections', (t) => {
+  const mapping = { mapped1: 'idx-1', mapped2: 'idx-2' }
+  t.deepEqual(
+    resolveCollectionIndices(['mapped1', 'unmapped', 'mapped2'], mapping),
+    ['idx-1', collectionUniqueIndexID('unmapped'), 'idx-2']
   )
 })

--- a/tests/unit/test-es.ts
+++ b/tests/unit/test-es.ts
@@ -1,6 +1,16 @@
 import test from 'ava'
-import { constructSearchParams, buildDatetimeQuery } from '../../src/lib/database.js'
-import type { QueryParameters } from '../../src/lib/types.js'
+import {
+  constructSearchParams,
+  buildDatetimeQuery,
+  collectionUniqueIndexID
+} from '../../src/lib/database.js'
+import type { OpenSearchFilterQuery, QueryParameters } from '../../src/lib/types.js'
+
+const indexFilterFor = (filters?: OpenSearchFilterQuery | OpenSearchFilterQuery[]) => {
+  if (!filters) return undefined
+  const list = Array.isArray(filters) ? filters : [filters]
+  return list.find((f) => f.terms?.['_index'])
+}
 
 test('search id parameter doesnt override other parameters', async (t) => {
   const ids = 'a,b,c'
@@ -78,9 +88,18 @@ test('search datetime parameter instants are correctly parsed', async (t) => {
   }))
 })
 
-test('if more than 10 collections are specified then all indices are searched', async (t) => {
-  const queryParams = { collections: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'] }
-  const params = await constructSearchParams(queryParams, 1)
+test('collections are scoped via an _index filter in the body, not the path', async (t) => {
+  const collections = ['a', 'b', 'c']
+  const params = await constructSearchParams({ collections }, 1)
 
-  t.deepEqual(params.index, ['_all'])
+  // The path keeps the default restriction; it does not list the collections.
+  t.deepEqual(params.index, ['*', '-.*', '-collections'])
+
+  // The collections are restricted via an _index terms filter in the body,
+  // using the hashed index ids.
+  const indexFilter = indexFilterFor(params.body.query.bool?.filter)
+  t.deepEqual(
+    indexFilter?.terms?.['_index'],
+    collections.map((c) => collectionUniqueIndexID(c))
+  )
 })

--- a/tests/unit/test-es.ts
+++ b/tests/unit/test-es.ts
@@ -13,6 +13,13 @@ const indexFilterFor = (filters?: OpenSearchFilterQuery | OpenSearchFilterQuery[
   return list.find((f) => f.terms?.['_index'])
 }
 
+// The index-scoping assertions below expect the default (non-mapping) index
+// restriction. Clear the mapping env var so an ambient value can't add mapped
+// remote indices and make these tests environment-dependent.
+test.beforeEach(() => {
+  delete process.env['COLLECTION_TO_INDEX_MAPPINGS']
+})
+
 test('search id parameter doesnt override other parameters', async (t) => {
   const ids = 'a,b,c'
   const range = '2007-03-01T13:00:00Z/2008-05-11T15:30:00Z'
@@ -89,8 +96,22 @@ test('search datetime parameter instants are correctly parsed', async (t) => {
   }))
 })
 
-test('collections are scoped via an _index filter in the body, not the path', async (t) => {
+test('a small collection list is scoped in the request path, not the body', async (t) => {
   const collections = ['a', 'b', 'c']
+  const params = await constructSearchParams({ collections }, 1)
+
+  // The path lists the resolved (hashed) indices so OpenSearch prunes shards at
+  // the coordinating node.
+  t.deepEqual(params.index, collections.map((c) => collectionUniqueIndexID(c)))
+
+  // No _index body filter is added in this case.
+  t.is(indexFilterFor(params.body.query.bool?.filter), undefined)
+})
+
+test('a large collection list falls back to an _index body filter', async (t) => {
+  // Enough collections that the joined hashed index names exceed the path-length
+  // limit, forcing the body-filter fallback.
+  const collections = Array.from({ length: 200 }, (_, i) => `collection-${i}`)
   const params = await constructSearchParams({ collections }, 1)
 
   // The path keeps the default restriction; it does not list the collections.

--- a/tests/unit/test-sns.ts
+++ b/tests/unit/test-sns.ts
@@ -1,0 +1,47 @@
+import test from 'ava'
+import { mockClient } from 'aws-sdk-client-mock'
+import { SNSClient, PublishCommand } from '@aws-sdk/client-sns'
+import { publishRecordToSns } from '../../src/lib/sns.js'
+import type { StacItem } from '../../src/lib/types.js'
+
+const snsMock = mockClient(SNSClient)
+
+const item = {
+  type: 'Feature',
+  id: 'test',
+  collection: 'test',
+  properties: {
+    datetime: '1955-11-05T13:00:00Z'
+  }
+} as StacItem
+
+const topicArn = 'arn:aws:sns:us-east-1:123456789012:post-ingest'
+
+test.beforeEach(() => {
+  snsMock.reset()
+})
+
+// Read the ingestStatus attribute off the PublishCommand the SNS client received.
+const publishedIngestStatus = () => {
+  const call = snsMock.commandCalls(PublishCommand)[0]
+  return call?.args[0].input.MessageAttributes?.['ingestStatus']?.StringValue
+}
+
+// Serial because these share the module-level SNS mock and assert on its
+// captured calls; running them concurrently would interleave the captures.
+test.serial('publishes ingestStatus "successful" when there is no error', async (t) => {
+  await publishRecordToSns(topicArn, item, undefined)
+  t.is(publishedIngestStatus(), 'successful')
+})
+
+test.serial('publishes ingestStatus "failed" when there is an error message', async (t) => {
+  await publishRecordToSns(topicArn, item, 'something went wrong')
+  t.is(publishedIngestStatus(), 'failed')
+})
+
+test.serial('publishes ingestStatus "failed" when the error message is empty', async (t) => {
+  // An ingest error with an empty message is still a failure; the status must
+  // not be derived from the truthiness of the message string.
+  await publishRecordToSns(topicArn, item, '')
+  t.is(publishedIngestStatus(), 'failed')
+})


### PR DESCRIPTION
I did a review of all the PRs that have landed this year, just to get another set of eyes on the recent changes. I found a handful of issues; this PR collects each of the fixes. None of them are large, so I felt like this was not a problem to batch them up, but I can split them apart if any are concerning.

**Related Issue(s):** 

- #770, #1047 (PR)
- #1038 (PR)
- #999 (PR)
- #1067 (PR)
- #1068 (PR)
- #1087 (PR)
- #1095 (PR)


**Proposed Changes:**

1. re-enable AVA worker threads via tsx nodeArguments (disabled on #1067)
2. husky pre-commit hook falls back gracefully when nvm is absent
3. scope collection searches via _index body filter (follow up to #770, #1047)
4. Tighten STAC types: bbox and collection summaries (initial types added #1068)
5. Fix ingestStatus mis-reporting for empty-message ingest errors (tightening up a bigfix committed as part of #1087)
6. Restore missing-href scenario in asset-proxy test (regression from #1095)
7. Preserve declared temporal sub-intervals during auto-extent calculation (fix for logic added in #999)
8. Resolve mapped collection indices without re-hashing (regression in #1038)

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
