### PR TITLE
Fix API docs endpoints in release artifacts

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -45,3 +45,11 @@ jobs:
         run: npm run test:system:coverage
       - name: Run build
         run: npm run build
+        env:
+          PRODUCTION: "true"
+      - name: Build lambda dist
+        run: npm run build-lambda-dist
+        env:
+          PRODUCTION: "true"
+      - name: Artifact smoke tests
+        run: npm run test:artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Artifact smoke test (`npm run test:artifact`) that unzips the built lambda ZIPs and invokes their bundled API handlers with a canned API Gateway event, catching bundle-only failures (webpack module interop, ZIP layout) that tests running against `src/` cannot see. Runs in the push workflow after the builds.
+- Artifact smoke test (`npm run test:artifact`) that unzips the built lambda ZIPs and invokes their bundled API handlers with a canned API Gateway event, catching bundle-only failures (webpack module interop, ZIP layout) that tests running against `src/` cannot see. Runs in the push workflow after the builds. ([1169](https://github.com/stac-utils/stac-server/pull/1169))
 
 ### Fixed
 
-- Fixed 404/500 responses from `/api` and `/api.html` when deploying the combined lambda-dist bundle. The API lambda resolves `openapi.yaml` and `redoc.html` against `LAMBDA_TASK_ROOT`, but the lambda-dist build copied them into the `api/` subdirectory of the ZIP. They are now copied to the ZIP root. Per-lambda ZIPs built with `npm run build` already placed them at the ZIP root and are unchanged.
-- Applied the v5.0.1 webpack/ts-loader interop fix to the per-lambda webpack configs (`api`, `ingest`, `pre-hook`, `post-hook`). v5.0.1 fixed only the combined lambda-dist config, so per-lambda ZIPs built with `npm run build` still crashed on first invocation with `TypeError: <logger>.<level> is not a function`.
+- Fixed 404/500 responses from `/api` and `/api.html` when deploying the combined lambda-dist bundle. The API lambda resolves `openapi.yaml` and `redoc.html` against `LAMBDA_TASK_ROOT`, but the lambda-dist build copied them into the `api/` subdirectory of the ZIP. They are now copied to the ZIP root. Per-lambda ZIPs built with `npm run build` already placed them at the ZIP root and are unchanged. ([1169](https://github.com/stac-utils/stac-server/pull/1169))
+- Applied the v5.0.1 webpack/ts-loader interop fix to the per-lambda webpack configs (`api`, `ingest`, `pre-hook`, `post-hook`). v5.0.1 fixed only the combined lambda-dist config, so per-lambda ZIPs built with `npm run build` still crashed on first invocation with `TypeError: <logger>.<level> is not a function`. ([1169](https://github.com/stac-utils/stac-server/pull/1169))
 
 ## [5.0.1] - 2026-07-30
 
@@ -655,6 +655,7 @@ Initial release, forked from [sat-api](https://github.com/sat-utils/sat-api/tree
 
 Compliant with STAC 0.9.0
 
+[5.0.2]: https://github.com/stac-utils/stac-api/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/stac-utils/stac-api/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/stac-utils/stac-api/compare/v4.5.0...v5.0.0
 [4.5.0]: https://github.com/stac-utils/stac-api/compare/v4.4.0...v4.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.0.2] - 2026-07-31
+
+### Added
+
+- Artifact smoke test (`npm run test:artifact`) that unzips the built lambda ZIPs and invokes their bundled API handlers with a canned API Gateway event, catching bundle-only failures (webpack module interop, ZIP layout) that tests running against `src/` cannot see. Runs in the push workflow after the builds.
+
+### Fixed
+
+- Fixed 404/500 responses from `/api` and `/api.html` when deploying the combined lambda-dist bundle. The API lambda resolves `openapi.yaml` and `redoc.html` against `LAMBDA_TASK_ROOT`, but the lambda-dist build copied them into the `api/` subdirectory of the ZIP. They are now copied to the ZIP root. Per-lambda ZIPs built with `npm run build` already placed them at the ZIP root and are unchanged.
+- Applied the v5.0.1 webpack/ts-loader interop fix to the per-lambda webpack configs (`api`, `ingest`, `pre-hook`, `post-hook`). v5.0.1 fixed only the combined lambda-dist config, so per-lambda ZIPs built with `npm run build` still crashed on first invocation with `TypeError: <logger>.<level> is not a function`.
+
 ## [5.0.1] - 2026-07-30
 
 ### Fixed

--- a/bin/artifact-smoke-test.js
+++ b/bin/artifact-smoke-test.js
@@ -1,0 +1,147 @@
+// Smoke-test the built lambda ZIP artifacts by invoking their bundled API
+// handlers with a canned API Gateway event. Catches bundle-only failures that
+// tests running against src/ cannot see (webpack module interop, ZIP layout).
+//
+// Requires dist/api/api.zip (npm run build) and
+// dist/lambda-dist/lambda-dist.zip (npm run build-lambda-dist) to exist.
+//
+// Usage: node bin/artifact-smoke-test.js
+// (--invoke <task-root> <handler-dir> is the internal per-bundle child mode;
+// each bundle needs its own process because LAMBDA_TASK_ROOT is captured at
+// module load.)
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const CHECKS = [
+  { path: '/', mustInclude: '"stac_version"' },
+  { path: '/conformance', mustInclude: 'conformsTo' },
+  { path: '/api', mustInclude: 'openapi' },
+  { path: '/api.html', mustInclude: 'redoc' },
+]
+
+// None of the checked routes query the database, so a placeholder host is
+// enough to let the app initialize.
+const CHILD_ENV = {
+  AWS_REGION: 'us-east-1',
+  ENABLE_TRANSACTIONS_EXTENSION: 'false',
+  OPENSEARCH_HOST: 'localhost:9200',
+}
+
+const apiGatewayEvent = (path) => ({
+  resource: '/{proxy+}',
+  path,
+  httpMethod: 'GET',
+  headers: { Host: 'example.com', 'X-Forwarded-Proto': 'https' },
+  multiValueHeaders: { Host: ['example.com'] },
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  pathParameters: path === '/' ? null : { proxy: path.slice(1) },
+  stageVariables: null,
+  body: null,
+  isBase64Encoded: false,
+  requestContext: {
+    accountId: '123456789012',
+    apiId: 'smoke-test',
+    authorizer: null,
+    protocol: 'HTTP/1.1',
+    httpMethod: 'GET',
+    identity: {
+      accessKey: null,
+      accountId: null,
+      caller: null,
+      cognitoAuthenticationProvider: null,
+      cognitoAuthenticationType: null,
+      cognitoIdentityId: null,
+      cognitoIdentityPoolId: null,
+      sourceIp: '127.0.0.1',
+      user: null,
+      userAgent: 'artifact-smoke-test',
+      userArn: null,
+    },
+    path,
+    stage: 'smoke-test',
+    requestId: 'artifact-smoke-test',
+    requestTimeEpoch: 0,
+    resourceId: 'smoke-test',
+    resourcePath: '/{proxy+}',
+  },
+})
+
+const invokeBundle = async (taskRoot, handlerDir) => {
+  process.env['LAMBDA_TASK_ROOT'] = taskRoot
+
+  const require = createRequire(import.meta.url)
+  // The bundle top-level-awaits its app creation, so module.exports is a
+  // promise; await unwraps it (and is a no-op if it ever becomes a plain object).
+  // eslint-disable-next-line import/no-dynamic-require
+  const { handler } = await require(join(handlerDir, 'index.js'))
+
+  let failures = 0
+  for (const { path, mustInclude } of CHECKS) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await handler(
+      apiGatewayEvent(path),
+      { getRemainingTimeInMillis: () => 30000 }
+    )
+    const body = result.isBase64Encoded
+      ? Buffer.from(result.body, 'base64').toString('utf8')
+      : String(result.body)
+
+    const problems = []
+    if (result.statusCode !== 200) problems.push(`status ${result.statusCode}`)
+    if (!body.includes(mustInclude)) problems.push(`body missing "${mustInclude}"`)
+
+    if (problems.length) {
+      failures += 1
+      console.error(`  FAIL GET ${path}: ${problems.join(', ')}`)
+    } else {
+      console.log(`  ok   GET ${path}`)
+    }
+  }
+  return failures
+}
+
+const runParent = () => {
+  const self = fileURLToPath(import.meta.url)
+  const artifacts = [
+    { zip: 'dist/api/api.zip', handlerSubdir: '.' },
+    { zip: 'dist/lambda-dist/lambda-dist.zip', handlerSubdir: 'api' },
+  ]
+
+  let failed = false
+  for (const { zip, handlerSubdir } of artifacts) {
+    if (existsSync(zip)) {
+      const dir = mkdtempSync(join(tmpdir(), 'stac-server-artifact-'))
+      try {
+        execFileSync('unzip', ['-q', zip, '-d', dir])
+        console.log(`${zip}:`)
+        const child = spawnSync(
+          process.execPath,
+          [self, '--invoke', dir, join(dir, handlerSubdir)],
+          { stdio: 'inherit', env: { ...process.env, ...CHILD_ENV } }
+        )
+        if (child.status !== 0) failed = true
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    } else {
+      console.error(`FAIL ${zip}: not found (run the build first)`)
+      failed = true
+    }
+  }
+
+  process.exit(failed ? 1 : 0)
+}
+
+if (process.argv[2] === '--invoke') {
+  const [, , , taskRoot, handlerDir] = process.argv
+  const failures = await invokeBundle(taskRoot, handlerDir)
+  process.exit(failures === 0 ? 0 : 1)
+} else {
+  runParent()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stac-server",
-  "version": "v5.0.1",
+  "version": "v5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stac-server",
-      "version": "v5.0.1",
+      "version": "v5.0.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.998.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint-js-fix": "eslint . --ext .js,.ts --fix",
     "check-openapi": "spectral lint src/lambdas/api/openapi.yaml --ruleset .spectral.yml",
     "test": "npm run test:unit && npm run test:system",
+    "test:artifact": "node bin/artifact-smoke-test.js",
     "test:system": "./bin/system-tests.sh",
     "test:system:coverage": "c8 npm run test:system",
     "test:unit": "NODE_OPTIONS='--import=tsx' ava tests/unit/*.[tj]s --no-worker-threads",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "stac-server",
   "description": "A STAC API running on stac-server",
-  "version": "v5.0.1",
+  "version": "v5.0.2",
   "repository": "https://github.com/stac-utils/stac-server",
   "author": "Alireza Jazayeri, Matthew Hanson, Sean Harkins, Phil Varner, Nate Rubin",
   "license": "MIT",

--- a/src/lambdas/api/webpack.config.js
+++ b/src/lambdas/api/webpack.config.js
@@ -33,11 +33,15 @@ export default {
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.[jt]s$/,
         use: {
           loader: 'ts-loader',
           options: {
             transpileOnly: true,
+            compilerOptions: {
+              module: 'esnext',
+              moduleResolution: 'bundler',
+            },
           },
         },
         exclude: /node_modules/,

--- a/src/lambdas/ingest/webpack.config.js
+++ b/src/lambdas/ingest/webpack.config.js
@@ -32,11 +32,15 @@ export default {
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.[jt]s$/,
         use: {
           loader: 'ts-loader',
           options: {
             transpileOnly: true,
+            compilerOptions: {
+              module: 'esnext',
+              moduleResolution: 'bundler',
+            },
           },
         },
         exclude: /node_modules/,

--- a/src/lambdas/post-hook/webpack.config.js
+++ b/src/lambdas/post-hook/webpack.config.js
@@ -32,11 +32,15 @@ export default {
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.[jt]s$/,
         use: {
           loader: 'ts-loader',
           options: {
             transpileOnly: true,
+            compilerOptions: {
+              module: 'esnext',
+              moduleResolution: 'bundler',
+            },
           },
         },
         exclude: /node_modules/,

--- a/src/lambdas/pre-hook/webpack.config.js
+++ b/src/lambdas/pre-hook/webpack.config.js
@@ -32,11 +32,15 @@ export default {
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.[jt]s$/,
         use: {
           loader: 'ts-loader',
           options: {
             transpileOnly: true,
+            compilerOptions: {
+              module: 'esnext',
+              moduleResolution: 'bundler',
+            },
           },
         },
         exclude: /node_modules/,

--- a/src/lambdas/webpack.config.js
+++ b/src/lambdas/webpack.config.js
@@ -57,13 +57,15 @@ export default {
   plugins: [
     new CopyPlugin({
       patterns: [
+        // The API lambda resolves these against LAMBDA_TASK_ROOT (the ZIP root),
+        // so they must land at the top level of the combined dist.
         {
           from: 'api/openapi.yaml',
-          to: 'api/openapi.yaml'
+          to: 'openapi.yaml'
         },
         {
           from: 'api/redoc.html',
-          to: 'api/redoc.html'
+          to: 'redoc.html'
         }
       ]
     }),


### PR DESCRIPTION
**Related Issue(s):**

- n/a — found while deploying the v5.0.0/v5.0.1 release assets via terraform-aws-stac-server

**Proposed Changes:**

1. Copy `openapi.yaml` and `redoc.html` to the lambda-dist ZIP root. The API lambda resolves them against `LAMBDA_TASK_ROOT` (the ZIP root), but the combined build placed them in the `api/` subdirectory, so `GET /api` returned 404 and `GET /api.html` returned 500. Per-lambda ZIPs already had them at the root and are unchanged.
2. Apply the v5.0.1 webpack/ts-loader interop fix (#1168) to the per-lambda webpack configs (`api`, `ingest`, `pre-hook`, `post-hook`), which were missed by that release. Their bundles still crashed on first invocation with `TypeError: <logger>.<level> is not a function`.
3. Add an artifact smoke test (`npm run test:artifact`) that unzips both built ZIPs and invokes the bundled API handlers with a canned API Gateway event, checking `/`, `/conformance`, `/api`, and `/api.html`. This catches bundle-only failures (webpack interop, ZIP layout) that tests running against `src/` cannot see — both v5.0.x release bugs would have failed it. Runs in the push workflow after the builds, which now build with `PRODUCTION=true` to match release artifacts. A PR for a more complete smoke test that tests more lambdas/endpoints will be opened on `main`.
4. Bump version to v5.0.2.

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
