### PR TITLE
Fix lambda dist api docs endpoints

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -45,3 +45,13 @@ jobs:
         run: npm run test:system:coverage
       - name: Run build
         run: npm run build
+        env:
+          PRODUCTION: "true"
+      - name: Build lambda dist
+        run: npm run build-lambda-dist
+        env:
+          PRODUCTION: "true"
+      - name: Artifact smoke tests
+        run: npm run test:artifact
+        env:
+          SMOKE_TEST_REQUIRE_DB: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Cleared production dependency advisories failing the `audit-prod` CI gate by updating
+  `body-parser` (GHSA-v422-hmwv-36x6) and `fast-uri` (GHSA-v2hh-gcrm-f6hx,
+  GHSA-4c8g-83qw-93j6) within their existing semver ranges.
 - Fixed 404/500 responses from `/api` and `/api.html` when deploying the combined
   lambda-dist bundle. The API lambda resolves `openapi.yaml` and `redoc.html` against
   `LAMBDA_TASK_ROOT` (the ZIP root), but the lambda-dist build copied them into the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Cleared production dependency advisories failing the `audit-prod` CI gate by updating
   `body-parser` (GHSA-v422-hmwv-36x6) and `fast-uri` (GHSA-v2hh-gcrm-f6hx,
-  GHSA-4c8g-83qw-93j6) within their existing semver ranges.
+  GHSA-4c8g-83qw-93j6) within their existing semver ranges. ([1170](https://github.com/stac-utils/stac-server/pull/1170))
 - Fixed 404/500 responses from `/api` and `/api.html` when deploying the combined
   lambda-dist bundle. The API lambda resolves `openapi.yaml` and `redoc.html` against
   `LAMBDA_TASK_ROOT` (the ZIP root), but the lambda-dist build copied them into the
   `api/` subdirectory of the ZIP. They are now copied to the ZIP root. Per-lambda
   ZIPs built with `npm run build` already placed them at the ZIP root and are
-  unchanged.
+  unchanged. ([1170](https://github.com/stac-utils/stac-server/pull/1170))
 - Scoped searches over collections configured with `COLLECTION_TO_INDEX_MAPPINGS`
   now target the mapped index name directly. Previously the mapped name was
   re-hashed as if it were a collection id, producing a nonexistent index and
@@ -79,7 +79,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   checked; with a local OpenSearch available, a test collection and item are ingested
   through the bundled ingest handler and all read endpoints are checked through the
   bundled API handler. Runs in the push workflow after the builds, which now build with
-  `PRODUCTION=true` to match release artifacts.
+  `PRODUCTION=true` to match release artifacts.  ([1170](https://github.com/stac-utils/stac-server/pull/1170))
 - Generating base STAC typescript types for typescript migration ([1068](https://github.com/stac-utils/stac-server/pull/1068))
 - Automatic temporal extent calculation for collections. When serving collections via the `/collections`
   and `/collections/{collectionId}` endpoints, any missing temporal extent bound is filled in from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   configs. ([596](https://github.com/stac-utils/stac-server/issues/596))
 
 ### Added
+- Artifact smoke test (`npm run test:artifact`) that unzips the built lambda ZIPs (both
+  the per-lambda and combined lambda-dist styles) and invokes their bundled handlers
+  with canned Lambda events, catching bundle-only failures (webpack module interop, ZIP
+  layout) that tests running against `src/` cannot see. Static routes are always
+  checked; with a local OpenSearch available, a test collection and item are ingested
+  through the bundled ingest handler and all read endpoints are checked through the
+  bundled API handler. Runs in the push workflow after the builds, which now build with
+  `PRODUCTION=true` to match release artifacts.
 - Generating base STAC typescript types for typescript migration ([1068](https://github.com/stac-utils/stac-server/pull/1068))
 - Automatic temporal extent calculation for collections. When serving collections via the `/collections`
   and `/collections/{collectionId}` endpoints, any missing temporal extent bound is filled in from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Fixed 404/500 responses from `/api` and `/api.html` when deploying the combined
+  lambda-dist bundle. The API lambda resolves `openapi.yaml` and `redoc.html` against
+  `LAMBDA_TASK_ROOT` (the ZIP root), but the lambda-dist build copied them into the
+  `api/` subdirectory of the ZIP. They are now copied to the ZIP root. Per-lambda
+  ZIPs built with `npm run build` already placed them at the ZIP root and are
+  unchanged.
 - Scoped searches over collections configured with `COLLECTION_TO_INDEX_MAPPINGS`
   now target the mapped index name directly. Previously the mapped name was
   re-hashed as if it were a collection id, producing a nonexistent index and

--- a/bin/artifact-smoke-test.js
+++ b/bin/artifact-smoke-test.js
@@ -1,0 +1,303 @@
+// Smoke-test the built lambda ZIP artifacts by invoking their bundled handlers
+// with canned Lambda events. Catches bundle-only failures that tests running
+// against src/ cannot see (webpack module interop, ZIP layout).
+//
+// Both packaging styles are tested: the per-lambda ZIPs (dist/api/api.zip,
+// dist/ingest/ingest.zip from npm run build) and the combined lambda-dist ZIP
+// (dist/lambda-dist/lambda-dist.zip from npm run build-lambda-dist).
+//
+// Static routes (/, /conformance, /api, /api.html) are always checked. When a
+// local OpenSearch is reachable at 127.0.0.1:9200 (the database client's
+// no-config default, as in the system tests), a test collection and item are
+// ingested through the bundled ingest handler and all read endpoints are
+// checked through the bundled API handler. Set SMOKE_TEST_REQUIRE_DB=true to
+// fail instead of skipping when OpenSearch is unreachable (used in CI, where
+// the service is expected).
+//
+// Usage: node bin/artifact-smoke-test.js
+// (--invoke-api and --invoke-ingest are internal per-bundle child modes; each
+// bundle needs its own process because LAMBDA_TASK_ROOT is captured at module
+// load.)
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const OPENSEARCH = '127.0.0.1:9200'
+
+// OPENSEARCH_HOST and ES_HOST are cleared so the bundled database client uses
+// its plain-HTTP local default; a set host would route it through AWS SigV4
+// auth.
+const CHILD_ENV = {
+  AWS_REGION: 'us-east-1',
+  ENABLE_TRANSACTIONS_EXTENSION: 'false',
+  OPENSEARCH_HOST: '',
+  ES_HOST: '',
+}
+
+const COLLECTION = {
+  type: 'Collection',
+  id: 'artifact-smoke-test',
+  stac_version: '1.1.0',
+  description: 'Throwaway collection ingested by bin/artifact-smoke-test.js',
+  license: 'proprietary',
+  extent: {
+    spatial: { bbox: [[-105.3, 39.9, -104.8, 40.1]] },
+    temporal: { interval: [['2024-06-01T00:00:00Z', '2024-06-30T23:59:59Z']] },
+  },
+  links: [],
+}
+
+const ITEM = {
+  type: 'Feature',
+  stac_version: '1.1.0',
+  id: 'artifact-smoke-test-item-1',
+  collection: 'artifact-smoke-test',
+  geometry: {
+    type: 'Polygon',
+    coordinates: [[[-105.1, 39.95], [-105.0, 39.95], [-105.0, 40.05],
+      [-105.1, 40.05], [-105.1, 39.95]]],
+  },
+  bbox: [-105.1, 39.95, -105.0, 40.05],
+  properties: { datetime: '2024-06-10T17:00:00Z' },
+  assets: {},
+  links: [],
+}
+
+const STATIC_CHECKS = [
+  { method: 'GET', path: '/', mustInclude: '"stac_version"' },
+  { method: 'GET', path: '/conformance', mustInclude: 'conformsTo' },
+  { method: 'GET', path: '/api', mustInclude: 'openapi' },
+  { method: 'GET', path: '/api.html', mustInclude: 'redoc' },
+]
+
+const DB_CHECKS = [
+  { method: 'GET', path: '/healthcheck', mustInclude: '"status":"ok"' },
+  { method: 'GET', path: '/queryables', mustInclude: 'schema' },
+  { method: 'GET', path: '/search', mustInclude: 'FeatureCollection' },
+  {
+    method: 'POST',
+    path: '/search',
+    body: '{"collections":["artifact-smoke-test"]}',
+    mustInclude: 'artifact-smoke-test-item-1',
+  },
+  { method: 'GET', path: '/aggregations', mustInclude: 'aggregations' },
+  { method: 'GET', path: '/collections', mustInclude: '"artifact-smoke-test"' },
+  { method: 'GET', path: '/collections/artifact-smoke-test', mustInclude: '"artifact-smoke-test"' },
+  { method: 'GET', path: '/collections/artifact-smoke-test/queryables', mustInclude: 'schema' },
+  {
+    method: 'GET',
+    path: '/collections/artifact-smoke-test/aggregations',
+    mustInclude: 'aggregations',
+  },
+  {
+    method: 'GET',
+    path: '/collections/artifact-smoke-test/items',
+    mustInclude: 'FeatureCollection',
+  },
+  {
+    method: 'GET',
+    path: '/collections/artifact-smoke-test/items/artifact-smoke-test-item-1',
+    mustInclude: 'artifact-smoke-test-item-1',
+  },
+]
+
+const apiGatewayEvent = ({ method, path, body }) => ({
+  resource: '/{proxy+}',
+  path,
+  httpMethod: method,
+  headers: {
+    Host: 'example.com',
+    'X-Forwarded-Proto': 'https',
+    'Content-Type': 'application/json',
+  },
+  multiValueHeaders: { Host: ['example.com'] },
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  pathParameters: path === '/' ? null : { proxy: path.slice(1) },
+  stageVariables: null,
+  body: body || null,
+  isBase64Encoded: false,
+  requestContext: {
+    accountId: '123456789012',
+    apiId: 'smoke-test',
+    authorizer: null,
+    protocol: 'HTTP/1.1',
+    httpMethod: method,
+    identity: {
+      accessKey: null,
+      accountId: null,
+      caller: null,
+      cognitoAuthenticationProvider: null,
+      cognitoAuthenticationType: null,
+      cognitoIdentityId: null,
+      cognitoIdentityPoolId: null,
+      sourceIp: '127.0.0.1',
+      user: null,
+      userAgent: 'artifact-smoke-test',
+      userArn: null,
+    },
+    path,
+    stage: 'smoke-test',
+    requestId: 'artifact-smoke-test',
+    requestTimeEpoch: 0,
+    resourceId: 'smoke-test',
+    resourcePath: '/{proxy+}',
+  },
+})
+
+const sqsEvent = (record) => ({
+  Records: [{ body: JSON.stringify(record) }],
+})
+
+const loadHandler = async (handlerDir) => {
+  const require = createRequire(import.meta.url)
+  // The api bundle top-level-awaits its app creation, so module.exports is a
+  // promise; await unwraps it (and passes plain objects through).
+  // eslint-disable-next-line import/no-dynamic-require
+  const { handler } = await require(join(handlerDir, 'index.js'))
+  return handler
+}
+
+const lambdaContext = { getRemainingTimeInMillis: () => 30000 }
+
+const invokeApi = async (taskRoot, handlerDir, withDb) => {
+  process.env['LAMBDA_TASK_ROOT'] = taskRoot
+  const handler = await loadHandler(handlerDir)
+
+  const checks = withDb ? [...STATIC_CHECKS, ...DB_CHECKS] : STATIC_CHECKS
+
+  let failures = 0
+  for (const check of checks) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await handler(apiGatewayEvent(check), lambdaContext)
+    const body = result.isBase64Encoded
+      ? Buffer.from(result.body, 'base64').toString('utf8')
+      : String(result.body)
+
+    const problems = []
+    if (result.statusCode !== 200) problems.push(`status ${result.statusCode}`)
+    if (!body.includes(check.mustInclude)) problems.push(`body missing "${check.mustInclude}"`)
+
+    if (problems.length) {
+      failures += 1
+      console.error(`  FAIL ${check.method} ${check.path}: ${problems.join(', ')}`)
+    } else {
+      console.log(`  ok   ${check.method} ${check.path}`)
+    }
+  }
+  return failures
+}
+
+const invokeIngest = async (handlerDir) => {
+  const handler = await loadHandler(handlerDir)
+
+  await handler({ create_indices: true }, lambdaContext)
+  await handler(sqsEvent(COLLECTION), lambdaContext)
+  await handler(sqsEvent(ITEM), lambdaContext)
+  console.log('  ok   ingest (create indices, collection, item)')
+}
+
+const opensearchReachable = async () => {
+  try {
+    const response = await fetch(`http://${OPENSEARCH}/`, { signal: AbortSignal.timeout(3000) })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+const refreshIndices = async () => {
+  await fetch(`http://${OPENSEARCH}/_refresh`, { method: 'POST' })
+}
+
+const unzip = (zip) => {
+  const dir = mkdtempSync(join(tmpdir(), 'stac-server-artifact-'))
+  execFileSync('unzip', ['-q', zip, '-d', dir])
+  return dir
+}
+
+const runChild = (self, args) => {
+  const child = spawnSync(process.execPath, [self, ...args], {
+    stdio: 'inherit',
+    env: { ...process.env, ...CHILD_ENV },
+  })
+  return child.status === 0
+}
+
+const runParent = async () => {
+  const self = fileURLToPath(import.meta.url)
+
+  const withDb = await opensearchReachable()
+  if (!withDb) {
+    const message = `OpenSearch is unreachable at ${OPENSEARCH}`
+    if (process.env['SMOKE_TEST_REQUIRE_DB'] === 'true') {
+      console.error(`FAIL ${message} and SMOKE_TEST_REQUIRE_DB is set`)
+      process.exit(1)
+    }
+    console.log(`${message} — checking static routes only`)
+  }
+
+  const styles = [
+    {
+      apiZip: 'dist/api/api.zip',
+      apiSubdir: '.',
+      ingestZip: 'dist/ingest/ingest.zip',
+      ingestSubdir: '.',
+    },
+    {
+      apiZip: 'dist/lambda-dist/lambda-dist.zip',
+      apiSubdir: 'api',
+      ingestZip: 'dist/lambda-dist/lambda-dist.zip',
+      ingestSubdir: 'ingest',
+    },
+  ]
+
+  let failed = false
+  for (const style of styles) {
+    const missing = [style.apiZip, style.ingestZip].filter((zip) => !existsSync(zip))
+    if (missing.length) {
+      console.error(`FAIL ${missing.join(', ')} not found (run the build first)`)
+      failed = true
+    } else {
+      const apiDir = unzip(style.apiZip)
+      const ingestDir = style.ingestZip === style.apiZip ? apiDir : unzip(style.ingestZip)
+      try {
+        console.log(`${style.apiZip}:`)
+        if (withDb) {
+          const ingested = runChild(self, ['--invoke-ingest', join(ingestDir, style.ingestSubdir)])
+          if (ingested) {
+            // eslint-disable-next-line no-await-in-loop
+            await refreshIndices()
+          } else {
+            failed = true
+          }
+        }
+        const dbFlag = withDb ? '1' : '0'
+        const apiArgs = ['--invoke-api', apiDir, join(apiDir, style.apiSubdir), dbFlag]
+        if (!runChild(self, apiArgs)) failed = true
+      } finally {
+        rmSync(apiDir, { recursive: true, force: true })
+        if (ingestDir !== apiDir) rmSync(ingestDir, { recursive: true, force: true })
+      }
+    }
+  }
+
+  process.exit(failed ? 1 : 0)
+}
+
+const mode = process.argv[2]
+if (mode === '--invoke-api') {
+  const [, , , taskRoot, handlerDir, dbFlag] = process.argv
+  const failures = await invokeApi(taskRoot, handlerDir, dbFlag === '1')
+  process.exit(failures === 0 ? 0 : 1)
+} else if (mode === '--invoke-ingest') {
+  const [, , , handlerDir] = process.argv
+  await invokeIngest(handlerDir)
+  process.exit(0)
+} else {
+  await runParent()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,9 @@
         "webpack": "^5.107.2",
         "webpack-cli": "^6.0.1",
         "zip-webpack-plugin": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6639,9 +6642,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -9200,9 +9203,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint-js-fix": "eslint . --ext .js,.ts --fix",
     "check-openapi": "spectral lint src/lambdas/api/openapi.yaml --ruleset .spectral.yml",
     "test": "npm run test:unit && npm run test:system",
+    "test:artifact": "node bin/artifact-smoke-test.js",
     "test:system": "./bin/system-tests.sh",
     "test:system:coverage": "c8 npm run test:system",
     "test:unit": "ava tests/unit/*.[tj]s",

--- a/src/lambdas/webpack.config.js
+++ b/src/lambdas/webpack.config.js
@@ -54,13 +54,15 @@ export default {
   plugins: [
     new CopyPlugin({
       patterns: [
+        // The API lambda resolves these against LAMBDA_TASK_ROOT (the ZIP root),
+        // so they must land at the top level of the combined dist.
         {
           from: 'api/openapi.yaml',
-          to: 'api/openapi.yaml'
+          to: 'openapi.yaml'
         },
         {
           from: 'api/redoc.html',
-          to: 'api/redoc.html'
+          to: 'redoc.html'
         }
       ]
     }),


### PR DESCRIPTION
**Related Issue(s):**

- n/a — found while deploying the v5.0.x release assets; forward-ports fixes from #1169 (v5.0.2) to main

**Proposed Changes:**

1. Copy `openapi.yaml` and `redoc.html` to the lambda-dist ZIP root. The API lambda resolves them against `LAMBDA_TASK_ROOT` (the ZIP root), but the combined build placed them in the `api/` subdirectory, so `GET /api` returned 404 and `GET /api.html` returned 500. Per-lambda ZIPs already had them at the root and are unchanged. 
2. Add an artifact smoke test (`npm run test:artifact`) that unzips both packaging styles (per-lambda ZIPs and the combined lambda-dist ZIP) and invokes the bundled handlers with canned Lambda events: it ingests a test collection and item through the bundled ingest handler, then checks every read endpoint through the bundled API handler (static routes plus healthcheck, queryables, GET/POST search, aggregations, and all collection/item routes — 32 checks total). This catches bundle-only failures (webpack module interop, ZIP layout) that tests running against `src/` cannot see (both v5.0.x release bugs would have failed it). The push workflow now also builds the lambda dist and builds with `PRODUCTION=true` to match release artifacts.
3. Clear the production dependency advisories currently failing `audit-prod` on main: `body-parser` 1.20.5 → 1.20.6 (GHSA-v422-hmwv-36x6) and `fast-uri` 3.1.2 → 3.1.5 (GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6), both within existing semver ranges — lock file only, no `package.json` changes.

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
